### PR TITLE
Bug fix for IndexOutOfBoundsException

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/reader/PathTokenizer.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/reader/PathTokenizer.java
@@ -84,7 +84,7 @@ public class PathTokenizer implements Iterable<PathToken> {
 
                 case '.':
                     poll();
-                    if (peek() == '.') {
+	                if (!isEmpty() && peek() == '.') {
                         poll();
                         fragments.add("..");
 

--- a/json-path/src/test/java/com/jayway/jsonpath/SplitPathFragmentsTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/SplitPathFragmentsTest.java
@@ -78,6 +78,13 @@ public class SplitPathFragmentsTest {
         assertPath("$..book[  ?(@.price<10)]", hasItems("$", "..", "book", "[?(@.price<10)]"));
     }
 
+	@Test
+	public void dot_ending_ignored() throws Exception {
+
+		assertPath("$..book['something'].", hasItems("$", "..", "something"));
+
+	}
+
     @Test
     public void invalid_path_throws_exception() throws Exception {
         assertPathInvalid("$...*");


### PR DESCRIPTION
If a json-path ended with a dot example: "$..book['something']." JsonPath would throw an IndexOutOfBoundsException. This is because PathTokenizer would do a peek() after a poll() without checking to see if the Tokenizer is empty.
