### PR TITLE
Make JsonPath work on Android 2.2

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -104,7 +104,7 @@ public class JsonPath {
 
     public JsonPath(String jsonPath, Filter[] filters) {
         if (jsonPath == null ||
-                jsonPath.trim().length()==0 ||
+                jsonPath.trim().length() == 0 ||
                 jsonPath.matches("[^\\?\\+\\=\\-\\*\\/\\!]\\(")) {
 
             throw new InvalidPathException("Invalid path");


### PR DESCRIPTION
Hi,

I just made a minor change to avoid the "NoSuchMethodException" thrown on Android 2.2 because the method `String#isEmpty` was added in 2.3.

I ran the unit tests and everything seems fine.  Please confirm and let me know if there is any issue.

Thanks!
Linton
