### PR TITLE
Project build improvements & refactored deprecated classes

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,24 @@
 Java DSL for reading and testing JSON documents.
 
 ------------------------------------------
+0.8.2-SNAPSHOT                  2013-01-24
+------------------------------------------
+- Changes from Gordon Dickens
+- Removed dependency on sonatype parent project
+- Added explicit versions for standard plugins
+- Added logging for tests, replacing sysout
+- Removed unnecessary boxing/unboxing of primitives
+- Added @Unchecked for test classes
+- Refactored out deprecated JUnit packages "junit.framework", replacing with Hamcrest matchers or "org.junit"
+- Added Maven Site Reporting
+  - run "mvn site"
+  - open "target/site/index.html"
+- NOTES:
+  - net.minidev:json-smart - is NOT OSGi compliant
+  - HttpProviderTest - refactor out sun.misc.IOUtils, its an internal proprietary API and may be removed in a future release
+  - JsonAssert.mapContainingKey() contains unchecked assignment, can this be improved?
+
+------------------------------------------
 0.8.1                           2012-04-16
 ------------------------------------------
 - Fixed issue http://code.google.com/p/json-path/issues/detail?id=11

--- a/json-path-assert/pom.xml
+++ b/json-path-assert/pom.xml
@@ -14,7 +14,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+           http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>json-path-parent</artifactId>
@@ -39,17 +42,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/JsonAssert.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/JsonAssert.java
@@ -67,6 +67,7 @@ public class JsonAssert {
         return new IsCollectionWithSize(sizeMatcher);
     }
 
+    //TODO Can this be generic?
     public static Matcher<Map<String, ?>> mapContainingKey(Matcher<String> keyMatcher) {
         return new IsMapContainingKey(keyMatcher);
     }
@@ -99,6 +100,4 @@ public class JsonAssert {
             return "";
         }
     }
-
-
 }

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
@@ -16,7 +16,6 @@ import static org.hamcrest.Matchers.*;
  */
 public class JsonAsserterImpl implements JsonAsserter {
 
-
     private final Object jsonObject;
 
 
@@ -33,6 +32,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> JsonAsserter assertThat(String path, Matcher<T> matcher) {
         T obj = JsonPath.<T>read(jsonObject, path);
@@ -46,6 +46,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <T> JsonAsserter assertEquals(String path, T expected) {
         return assertThat(path, equalTo(expected));
     }
@@ -53,12 +54,13 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public JsonAsserter assertNotDefined(String path) {
 
         try {
             Object o = JsonPath.read(jsonObject, path);
             throw new AssertionError(format("Document contains the path <%s> but was expected not to.", path));
-        } catch (InvalidPathException e) {
+        } catch (InvalidPathException ignored) {
         }
         return this;
     }
@@ -66,6 +68,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public JsonAsserter assertNull(String path) {
         return assertThat(path, nullValue());
     }
@@ -73,6 +76,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <T> JsonAsserter assertNotNull(String path) {
         return assertThat(path, notNullValue());
     }
@@ -80,6 +84,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public JsonAsserter and() {
         return this;
     }

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/CollectionMatcher.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/CollectionMatcher.java
@@ -34,12 +34,10 @@ import org.hamcrest.BaseMatcher;
 import java.util.Collection;
 
 public abstract class CollectionMatcher<C extends Collection<?>> extends BaseMatcher<C> {
+    @Override
     @SuppressWarnings("unchecked")
     public boolean matches(Object item) {
-        if (!(item instanceof Collection)) {
-            return false;
-        }
-        return matchesSafely((C)item);
+        return item instanceof Collection && matchesSafely((C) item);
     }
 
     protected abstract boolean matchesSafely(C collection);

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsCollectionWithSize.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsCollectionWithSize.java
@@ -52,9 +52,10 @@ public class IsCollectionWithSize<E> extends CollectionMatcher<Collection<? exte
         return sizeMatcher.matches(item.size());
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("a collection with size ")
-            .appendDescriptionOf(sizeMatcher);
+                .appendDescriptionOf(sizeMatcher);
     }
 
     /**
@@ -67,9 +68,9 @@ public class IsCollectionWithSize<E> extends CollectionMatcher<Collection<? exte
 
     /**
      * This is a shortcut to the frequently used hasSize(equalTo(x)).
-     *
+     * <p/>
      * For example,  assertThat(hasSize(equal_to(x)))
-     *          vs.  assertThat(hasSize(x))
+     * vs.  assertThat(hasSize(x))
      */
     @Factory
     public static <E> Matcher<? super Collection<? extends E>> hasSize(int size) {

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsEmptyCollection.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsEmptyCollection.java
@@ -45,6 +45,7 @@ public class IsEmptyCollection<E> extends CollectionMatcher<Collection<E>> {
         return item.isEmpty();
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("an empty collection");
     }

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingKey.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingKey.java
@@ -54,6 +54,7 @@ public class IsMapContainingKey<K> extends MapTypeSafeMatcher<Map<K,?>> {
         return false;
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("map with key ")
                    .appendDescriptionOf(keyMatcher);

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingValue.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingValue.java
@@ -54,6 +54,7 @@ public class IsMapContainingValue<V> extends MapTypeSafeMatcher<Map<?,V>>{
         return false;
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("map with value ")
                    .appendDescriptionOf(valueMatcher);

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/MapTypeSafeMatcher.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/MapTypeSafeMatcher.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 public abstract class MapTypeSafeMatcher<M extends Map<?, ?>> extends BaseMatcher<M> {
     @SuppressWarnings("unchecked")
+    @Override
     public boolean matches(Object item) {
         return item instanceof Map && matchesSafely((M) item);
     }

--- a/json-path-assert/src/test/java/com/jayway/jsonassert/JsonAssertTest.java
+++ b/json-path-assert/src/test/java/com/jayway/jsonassert/JsonAssertTest.java
@@ -56,14 +56,13 @@ public class JsonAssertTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void links_document() throws Exception {
-
         with(getResourceAsStream("links.json")).assertEquals("count", 2)
                 .assertThat("links.gc:this.href", endsWith("?pageNumber=1&pageSize=2"))
                 .assertNotDefined("links.gc:prev")
                 .assertNotDefined("links.gc:next")
                 .assertThat("rows", collectionWithSize(equalTo(2)));
-
     }
 
 
@@ -90,6 +89,7 @@ public class JsonAssertTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void list_content_can_be_asserted_with_matcher() throws Exception {
 
         with(JSON).assertThat("$..book[*].author", hasItems("Nigel Rees", "Evelyn Waugh", "Herman Melville", "J. R. R. Tolkien"));
@@ -99,6 +99,7 @@ public class JsonAssertTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void list_content_can_be_asserted_with_nested_matcher() throws Exception {
         with(JSON).assertThat("$..book[*]", hasItems(hasEntry("author", "Nigel Rees"), hasEntry("author", "Evelyn Waugh")));
     }

--- a/json-path-assert/src/test/resources/logback-test.xml
+++ b/json-path-assert/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%.-1level|%-20.25logger{0}| %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.jayway" level="debug"/>
+
+    <root level="warn">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -14,20 +14,24 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+           http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path-parent</artifactId>
         <version>0.8.2-SNAPSHOT</version>
     </parent>
+
     <artifactId>json-path</artifactId>
     <packaging>bundle</packaging>
     <name>json-path</name>
     <url>http://code.google.com/p/json-path/</url>
     <dependencies>
 
-
+        <!--  N.B. JSON Smart is NOT OSGi Ready -->
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
@@ -48,20 +52,11 @@
         <!-- test dependencies            -->
         <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
-
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-
     </dependencies>
 
     <build>

--- a/json-path/src/main/java/com/jayway/jsonpath/Filter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Filter.java
@@ -100,6 +100,7 @@ public abstract class Filter<T> {
             addCriteria(criteria);
         }
 
+        @Override
         public MapFilter addCriteria(Criteria criteria) {
             Criteria existing = this.criteria.get(criteria.getKey());
             String key = criteria.getKey();

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathTokenizer.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathTokenizer.java
@@ -62,6 +62,7 @@ public class PathTokenizer implements Iterable<PathToken> {
         return new LinkedList<PathToken>(pathTokens);
     }
 
+    @Override
     public Iterator<PathToken> iterator() {
         return pathTokens.iterator();
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FieldFilter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FieldFilter.java
@@ -64,6 +64,7 @@ public class FieldFilter extends PathTokenFilter {
     }
 
 
+    @Override
     public Object filter(Object obj, JsonProvider jsonProvider) {
         if (jsonProvider.isList(obj)) {
             return obj;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/PassthroughFilter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/PassthroughFilter.java
@@ -29,6 +29,7 @@ public class PassthroughFilter extends PathTokenFilter {
         this.isArrayFilter = isArrayFilter;
     }
 
+    @Override
     public Object filter(Object obj, JsonProvider jsonProvider) {
         return obj;
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/impl/AbstractJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/impl/AbstractJsonProvider.java
@@ -37,6 +37,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj object to check
      * @return true if List or Map
      */
+    @Override
     public boolean isContainer(Object obj) {
         return (isList(obj) || isMap(obj));
     }
@@ -47,6 +48,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj object to check
      * @return true if List
      */
+    @Override
     public boolean isList(Object obj) {
         return (obj instanceof List);
     }
@@ -57,6 +59,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param list object to convert
      * @return object as list
      */
+    @Override
     @SuppressWarnings({"unchecked"})
     public List<Object> toList(Object list) {
         return (List<Object>) list;
@@ -69,6 +72,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param map object to convert
      * @return object as map
      */
+    @Override
     @SuppressWarnings({"unchecked"})
     public Map<String, Object> toMap(Object map) {
         return (Map<String, Object>) map;
@@ -81,6 +85,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param key key to read
      * @return value of key in map
      */
+    @Override
     public Object getMapValue(Object map, String key) {
         return toMap(map).get(key);
     }
@@ -91,6 +96,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj object to check
      * @return true if Map
      */
+    @Override
     public boolean isMap(Object obj) {
         return (obj instanceof Map);
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/impl/JsonSmartJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/impl/JsonSmartJsonProvider.java
@@ -45,14 +45,17 @@ public class JsonSmartJsonProvider extends AbstractJsonProvider {
         this.parser = new JSONParser(mode.intValue());
     }
 
+    @Override
     public Map<String, Object> createMap() {
         return new JSONObject();
     }
 
+    @Override
     public List<Object> createList() {
         return new JSONArray();
     }
 
+    @Override
     public Object parse(String json) {
         try {
             return parser.parse(json);
@@ -91,6 +94,7 @@ public class JsonSmartJsonProvider extends AbstractJsonProvider {
         }
     }
 
+    @Override
     public Mode getMode() {
         return mode;
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/ComplianceTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/ComplianceTest.java
@@ -39,10 +39,10 @@ public class ComplianceTest {
         assertThat(JsonPath.<Integer>read(json, "$[0]"), is(equalTo(1)));
         assertThat(JsonPath.<Integer>read(json, "$[4]"), is(equalTo(null)));
         assertThat(JsonPath.<List<Comparable>>read(json, "$[*]"), hasItems(
-                new Integer(1),
-                new String("2"),
-                new Double(3.14),
-                new Boolean(true),
+                1,
+                "2",
+                3.14,
+                true,
                 (Comparable)null));
         assertThat(JsonPath.<Boolean>read(json, "$[-1:]"), is(equalTo(null)));
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/HttpProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/HttpProviderTest.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 
 /**
  * Created by IntelliJ IDEA.
@@ -16,6 +18,7 @@ import static junit.framework.Assert.assertEquals;
  * Date: 3/10/12
  * Time: 8:12 AM
  */
+@SuppressWarnings("unchecked")
 public class HttpProviderTest {
 
 
@@ -23,7 +26,7 @@ public class HttpProviderTest {
             "   \"results\" : [],\n" +
             "   \"status\" : \"REQUEST_DENIED\"\n" +
             "}";
-    
+
     @Test
     public void http_get() throws Exception {
 
@@ -31,16 +34,16 @@ public class HttpProviderTest {
 
         InputStream inputStream = null;
         try {
-            inputStream =  HttpProviderFactory.getProvider().get(url);
-
+            inputStream = HttpProviderFactory.getProvider().get(url);
+//TODO - Refactor out - sun.misc.IOUtils is internal proprietary API and may be removed in a future release
             byte[] bytes = sun.misc.IOUtils.readFully(inputStream, -1, true);
-            
+
             String json = new String(bytes).trim();
 
-            assertEquals(EXPECTED, json);
+            assertThat(EXPECTED, equalTo(json));
 
         } catch (IOException e) {
-             IOUtils.closeQuietly(inputStream);
+            IOUtils.closeQuietly(inputStream);
         }
 
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/IssuesTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/IssuesTest.java
@@ -1,12 +1,15 @@
 package com.jayway.jsonpath;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static com.jayway.jsonpath.JsonPath.compile;
+import static com.jayway.jsonpath.JsonPath.read;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by IntelliJ IDEA.
@@ -15,6 +18,8 @@ import static junit.framework.Assert.assertTrue;
  * Time: 8:42 AM
  */
 public class IssuesTest {
+    private static final Logger logger = LoggerFactory.getLogger(IssuesTest.class);
+
     @Test
     public void issue_7() throws Exception {
 
@@ -25,17 +30,17 @@ public class IssuesTest {
                 "  ] }";
 
 
-        assertNull(JsonPath.read(json, "$.foo.id"));
+        assertNull(read(json, "$.foo.id"));
     }
-    
+
     @Test
     public void issue_11() throws Exception {
         String json = "{ \"foo\" : [] }";
-        List<String> result = JsonPath.read(json, "$.foo[?(@.rel= 'item')][0].uri");
+        List<String> result = read(json, "$.foo[?(@.rel= 'item')][0].uri");
 
-        System.out.println(JsonPath.compile("$.foo[?(@.rel= 'item')][0].uri").isPathDefinite());
-        System.out.println(JsonPath.compile("$.foo[?(@.rel= 'item')][0]").isPathDefinite());
-        System.out.println(JsonPath.compile("$.foo[?(@.rel= 'item')]").isPathDefinite());
+        logger.debug("{}", compile("$.foo[?(@.rel= 'item')][0].uri").isPathDefinite());
+        logger.debug("{}", compile("$.foo[?(@.rel= 'item')][0]").isPathDefinite());
+        logger.debug("{}", compile("$.foo[?(@.rel= 'item')]").isPathDefinite());
 
         assertTrue(result.isEmpty());
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonModelChainedCallsTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonModelChainedCallsTest.java
@@ -1,11 +1,15 @@
 package com.jayway.jsonpath;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 
 /**
  * Created by IntelliJ IDEA.
@@ -14,7 +18,8 @@ import static junit.framework.Assert.assertEquals;
  * Time: 7:30 AM
  */
 public class JsonModelChainedCallsTest {
-    
+    private static final Logger logger = LoggerFactory.getLogger(JsonModelChainedCallsTest.class);
+
     public final static String DOCUMENT =
             "{ \"store\": {\n" +
                     "    \"book\": [ \n" +
@@ -50,13 +55,13 @@ public class JsonModelChainedCallsTest {
                     "    }\n" +
                     "  }\n" +
                     "}";
-    
-    
+
+
     @Test
     public void convert_and_map() throws Exception {
-     
+
         JsonModel model = JsonModel.model(DOCUMENT);
-        
+
         Transformer<Map<String, Object>> transformer = new Transformer<Map<String, Object>>() {
             @Override
             public Object transform(Map<String, Object> map) {
@@ -68,15 +73,16 @@ public class JsonModelChainedCallsTest {
 
         Book book = model.opsForObject("store.book[0]").transform(transformer).to(Book.class);
 
-        assertEquals(book.author, "kalle");
+        assertThat(book.author, equalTo("kalle"));
     }
-    
-        
+
+
     @Test
+    @SuppressWarnings("unchecked")
     public void convert_each_and_map() throws Exception {
-     
+
         JsonModel model = JsonModel.model(DOCUMENT);
-        
+
         Transformer<Object> transformer = new Transformer<Object>() {
             @Override
             public Object transform(Object obj) {
@@ -89,15 +95,15 @@ public class JsonModelChainedCallsTest {
 
         List<Book> books = model.opsForArray("store.book").each(transformer).toList().of(Book.class);
 
-        System.out.println();
+        logger.debug("");
     }
-    
-    
+
+
     public static class Book {
         public String category;
         public String author;
         public String title;
         public Double price;
     }
-    
+
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonModelMappingTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonModelMappingTest.java
@@ -1,6 +1,8 @@
 package com.jayway.jsonpath;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Set;
@@ -8,7 +10,9 @@ import java.util.Set;
 import static com.jayway.jsonpath.Criteria.where;
 import static com.jayway.jsonpath.Filter.filter;
 import static com.jayway.jsonpath.JsonModel.model;
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 
 /**
  * Created by IntelliJ IDEA.
@@ -17,6 +21,7 @@ import static junit.framework.Assert.assertEquals;
  * Time: 8:36 PM
  */
 public class JsonModelMappingTest {
+    private static final Logger logger = LoggerFactory.getLogger(JsonModelMappingTest.class);
 
     public final static String DOCUMENT =
             "{ \"store\": {\n" +
@@ -52,14 +57,14 @@ public class JsonModelMappingTest {
                     "    }\n" +
                     "  }\n" +
                     "}";
-    
-    
+
+
     @Test
     public void map_and_filter_can_be_combined() throws Exception {
-     
-        
+
+
         JsonModel model = JsonModel.model(DOCUMENT);
-        
+
         Filter filter = Filter.filter(Criteria.where("category").is("fiction").and("price").gt(10D));
 
         List<Book> books = model.map("$.store.book[?]", filter).toList().of(Book.class);
@@ -74,8 +79,8 @@ public class JsonModelMappingTest {
         model(DOCUMENT);
 
 
-        System.out.println("");
-        
+        logger.debug("");
+
     }
 
     @Test
@@ -85,10 +90,10 @@ public class JsonModelMappingTest {
 
         Book book = model.map("$.store.book[1]").to(Book.class);
 
-        assertEquals("fiction", book.category);
-        assertEquals("Evelyn Waugh", book.author);
-        assertEquals("Sword of Honour", book.title);
-        assertEquals(12.99D, book.price);
+        assertThat("fiction", equalTo(book.category));
+        assertThat("Evelyn Waugh", equalTo(book.author));
+        assertThat("Sword of Honour", equalTo(book.title));
+        assertThat(12.99D, equalTo(book.price));
     }
 
     @Test
@@ -97,24 +102,24 @@ public class JsonModelMappingTest {
 
         List<Book> booksList = model.map("$.store.book[0,1]").toListOf(Book.class);
 
-        assertEquals("fiction", booksList.get(1).category);
-        assertEquals("Evelyn Waugh", booksList.get(1).author);
-        assertEquals("Sword of Honour", booksList.get(1).title);
-        assertEquals(12.99D, booksList.get(1).price);
+        assertThat("fiction", equalTo(booksList.get(1).category));
+        assertThat("Evelyn Waugh", equalTo(booksList.get(1).author));
+        assertThat("Sword of Honour", equalTo(booksList.get(1).title));
+        assertThat(12.99D, equalTo(booksList.get(1).price));
 
         booksList = model.map("$.store.book[*]").toListOf(Book.class);
 
-        assertEquals("fiction", booksList.get(1).category);
-        assertEquals("Evelyn Waugh", booksList.get(1).author);
-        assertEquals("Sword of Honour", booksList.get(1).title);
-        assertEquals(12.99D, booksList.get(1).price);
+        assertThat("fiction", equalTo(booksList.get(1).category));
+        assertThat("Evelyn Waugh", equalTo(booksList.get(1).author));
+        assertThat("Sword of Honour", equalTo(booksList.get(1).title));
+        assertThat(12.99D, equalTo(booksList.get(1).price));
 
         booksList = model.map("$.store.book[*]").toList().of(Book.class);
 
-        assertEquals("fiction", booksList.get(1).category);
-        assertEquals("Evelyn Waugh", booksList.get(1).author);
-        assertEquals("Sword of Honour", booksList.get(1).title);
-        assertEquals(12.99D, booksList.get(1).price);
+        assertThat("fiction", equalTo(booksList.get(1).category));
+        assertThat("Evelyn Waugh", equalTo(booksList.get(1).author));
+        assertThat("Sword of Honour", equalTo(booksList.get(1).title));
+        assertThat(12.99D, equalTo(booksList.get(1).price));
     }
 
     @Test
@@ -126,10 +131,10 @@ public class JsonModelMappingTest {
 
         Book book = bookSet.iterator().next();
 
-        assertEquals("fiction", book.category);
-        assertEquals("Evelyn Waugh", book.author);
-        assertEquals("Sword of Honour", book.title);
-        assertEquals(12.99D, book.price);
+        assertThat("fiction", equalTo(book.category));
+        assertThat("Evelyn Waugh", equalTo(book.author));
+        assertThat("Sword of Honour", equalTo(book.title));
+        assertThat(12.99D, equalTo(book.price));
     }
 
 

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonModelOpsTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonModelOpsTest.java
@@ -5,7 +5,9 @@ import org.junit.Test;
 import java.util.*;
 
 import static com.jayway.jsonpath.JsonModel.model;
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 /**
  * Created by IntelliJ IDEA.
@@ -13,6 +15,7 @@ import static junit.framework.Assert.assertEquals;
  * Date: 3/4/12
  * Time: 4:55 PM
  */
+@SuppressWarnings("unchecked")
 public class JsonModelOpsTest {
 
     public final static String DOCUMENT =
@@ -58,9 +61,9 @@ public class JsonModelOpsTest {
 
         JsonModel.ObjectOps ops = model.opsForObject();
 
-        assertEquals(19.95D, ops.getDouble("price"));
-        assertEquals(new Long(12), ops.getLong("number"));
-        assertEquals(new Integer(12), ops.getInteger("number"));
+        assertThat(19.95D, equalTo(ops.getDouble("price")));
+        assertThat(12L, equalTo(ops.getLong("number")));
+        assertThat(12, equalTo(ops.getInteger("number")));
 
         int i = ops.getInteger("number");
         long l = ops.getLong("number");
@@ -76,8 +79,8 @@ public class JsonModelOpsTest {
                 .put("author", "Kalle")
                 .put("price", 12.30D);
 
-        assertEquals("Kalle", model.get("store.book[0].author"));
-        assertEquals(12.30D, model.get("store.book[0].price"));
+        assertThat("Kalle", equalTo(model.get("store.book[0].author")));
+        assertThat(12.30D, equalTo(model.get("store.book[0].price")));
     }
 
 
@@ -96,11 +99,11 @@ public class JsonModelOpsTest {
 
         JsonModel subModel = model.getSubModel("store.book[4]");
 
-        assertEquals("reference", subModel.get("category"));
-        assertEquals("Kalle", subModel.get("author"));
-        assertEquals("JSONPath book", subModel.get("title"));
-        assertEquals("0-553-21311-34", subModel.get("isbn"));
-        assertEquals(12.10D, subModel.get("price"));
+        assertThat("reference", equalTo(subModel.get("category")));
+        assertThat("Kalle", equalTo(subModel.get("author")));
+        assertThat("JSONPath book", equalTo(subModel.get("title")));
+        assertThat("0-553-21311-34", equalTo(subModel.get("isbn")));
+        assertThat(12.10D, equalTo(subModel.get("price")));
     }
 
     @Test
@@ -122,10 +125,10 @@ public class JsonModelOpsTest {
                 return obj;
             }
         });
-        assertEquals("kalle", model.get("name"));
+        assertThat("kalle", equalTo(model.get("name")));
     }
-    
-    
+
+
     @Test
     public void ops_can_transform_array_root() throws Exception {
 
@@ -142,7 +145,7 @@ public class JsonModelOpsTest {
                 return Collections.singletonMap("root", "new");
             }
         });
-        assertEquals("new", model.get("root"));
+        assertThat("new", equalTo(model.get("root")));
     }
 
     @Test
@@ -169,7 +172,7 @@ public class JsonModelOpsTest {
             }
         });
 
-        assertEquals("kalle", model.get("child.name"));
+        assertThat("kalle", equalTo(model.get("child.name")));
     }
 
     @Test
@@ -180,9 +183,9 @@ public class JsonModelOpsTest {
         List<Book> books2 = model.opsForArray("store.book").toListOf(Book.class);
         Set<Book> books3 = model.opsForArray("store.book").toSetOf(Book.class);
 
-        assertEquals(4, books1.size());
-        assertEquals(4, books2.size());
-        assertEquals(4, books3.size());
+        assertThat(books1, hasSize(4));
+        assertThat(books2, hasSize(4));
+        assertThat(books3, hasSize(4));
     }
 
     @Test
@@ -191,10 +194,10 @@ public class JsonModelOpsTest {
 
         Book book = model.opsForObject("store.book[1]").to(Book.class);
 
-        assertEquals("fiction", book.category);
-        assertEquals("Evelyn Waugh", book.author);
-        assertEquals("Sword of Honour", book.title);
-        assertEquals(12.99D, book.price);
+        assertThat("fiction", equalTo(book.category));
+        assertThat("Evelyn Waugh", equalTo(book.author));
+        assertThat("Sword of Honour", equalTo(book.title));
+        assertThat(12.99D, equalTo(book.price));
 
     }
 
@@ -214,7 +217,7 @@ public class JsonModelOpsTest {
 
         model.opsForObject("store.book[1]").transform(transformer);
 
-        assertEquals("newProp", model.get("store.book[1].newProp"));
+        assertThat("newProp", equalTo(model.get("store.book[1].newProp")));
     }
 
     @Test
@@ -236,7 +239,7 @@ public class JsonModelOpsTest {
 
         model.opsForArray("store.book").transform(transformer);
 
-        assertEquals("newProp", model.get("store.book[1].newProp"));
+        assertThat("newProp", equalTo(model.get("store.book[1].newProp")));
     }
 
     @Test
@@ -249,7 +252,7 @@ public class JsonModelOpsTest {
                 List<Object> newList = new ArrayList<Object>();
 
                 for (Object o : model) {
-                    newList.add(new Integer(i++));
+                    newList.add(i++);
                 }
 
                 return newList;
@@ -273,7 +276,7 @@ public class JsonModelOpsTest {
 
         model.opsForArray("store.book").transform(positionTransformer).transform(multiplyingTransformer);
 
-        assertEquals(2, model.get("store.book[1]"));
+        assertThat(2, equalTo(model.get("store.book[1]")));
     }
 
     public static class Book {

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonModelSubModelDetachedTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonModelSubModelDetachedTest.java
@@ -2,7 +2,9 @@ package com.jayway.jsonpath;
 
 import org.junit.Test;
 import static com.jayway.jsonpath.JsonModel.model;
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 
 /**
  * Created by IntelliJ IDEA.
@@ -56,10 +58,8 @@ public class JsonModelSubModelDetachedTest {
 
         detachedModel.opsForArray().add(1);
 
-        assertEquals(4, model.opsForArray("$.store.book").size());
-        assertEquals(5, detachedModel.opsForArray("$.store.book").size());
+        assertThat(4, equalTo(model.opsForArray("$.store.book").size()));
+        assertThat(5, equalTo(detachedModel.opsForArray("$.store.book").size()));
 
     }
-
-
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonModelSubModelTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonModelSubModelTest.java
@@ -5,7 +5,9 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 
 /**
  * Created by IntelliJ IDEA.
@@ -67,8 +69,8 @@ public class JsonModelSubModelTest {
     @Test
     public void test_a_sub_model_can_be_fetched_and_read() throws Exception {
         JsonModel model = JsonModel.model(DOCUMENT);
-        assertEquals("Nigel Rees", model.getSubModel("$store.book[0]").get("author"));
-        assertEquals("Nigel Rees", model.getSubModel(JsonPath.compile("$store.book[0]")).get("author"));
+        assertThat("Nigel Rees", equalTo(model.getSubModel("$store.book[0]").get("author")));
+        assertThat("Nigel Rees", equalTo(model.getSubModel(JsonPath.compile("$store.book[0]")).get("author")));
     }
 
 
@@ -80,12 +82,12 @@ public class JsonModelSubModelTest {
         JsonModel subModel = model.getSubModel("store.book[0]");
         subModel.opsForObject().put("author", "kalle");
 
-        assertEquals("kalle", model.get("store.book[0].author"));
+        assertThat("kalle", equalTo(model.get("store.book[0].author")));
     }
-    
+
     @Test
     public void when_a_sub_model_root_is_transformed_the_master_model_is_updated() throws Exception {
-            
+
         JsonModel model = JsonModel.model(DOCUMENT);
 
         JsonModel subModel = model.getSubModel("store.book[0]");
@@ -95,7 +97,7 @@ public class JsonModelSubModelTest {
                 return Collections.singletonMap("prop", "new");
             }
         });
-        assertEquals("new", model.get("store.book[0].prop"));
+        assertThat("new", equalTo(model.get("store.book[0].prop")));
     }
 
     @Test
@@ -110,7 +112,7 @@ public class JsonModelSubModelTest {
                 return Collections.singletonMap("prop", "new");
             }
         });
-        assertEquals("new", model.get("store.bicycle.book.prop"));
+        assertThat("new", equalTo(model.get("store.bicycle.book.prop")));
     }
 
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonModelTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonModelTest.java
@@ -9,9 +9,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by IntelliJ IDEA.
@@ -67,24 +68,23 @@ public class JsonModelTest {
     @Test
     public void has_path_validates() throws Exception {
         assertFalse(JsonModel.model(DOCUMENT).hasPath("store.invalid"));
-        assertFalse( JsonModel.model(DOCUMENT).hasPath("store.book[0].foo"));
+        assertFalse(JsonModel.model(DOCUMENT).hasPath("store.book[0].foo"));
 
-        assertTrue( JsonModel.model(DOCUMENT).hasPath("store.book"));
-        assertTrue( JsonModel.model(DOCUMENT).hasPath("store.book[0].title"));
+        assertTrue(JsonModel.model(DOCUMENT).hasPath("store.book"));
+        assertTrue(JsonModel.model(DOCUMENT).hasPath("store.book[0].title"));
     }
-    
+
     @Test
     public void a_json_document_can_be_fetched_with_a_URL() throws Exception {
         URL url = new URL("http://maps.googleapis.com/maps/api/geocode/json");
-        assertEquals("REQUEST_DENIED", JsonModel.model(url).get("status"));
+        assertThat("REQUEST_DENIED", equalTo(JsonModel.model(url).get("status")));
     }
 
     @Test
     public void a_json_document_can_be_fetched_with_a_InputStream() throws Exception {
         ByteArrayInputStream bis = new ByteArrayInputStream(DOCUMENT.getBytes());
-        assertEquals("Nigel Rees", JsonModel.model(bis).get("store.book[0].author"));
+        assertThat("Nigel Rees", equalTo(JsonModel.model(bis).get("store.book[0].author")));
     }
-
 
 
     @Test
@@ -95,9 +95,9 @@ public class JsonModelTest {
 
         JsonModel model = JsonModel.model(doc);
 
-        assertEquals("value", model.get("$child.key"));
-        assertEquals(1, model.get("$items[1]"));
-        assertEquals("{\"child\":{\"key\":\"value\"},\"items\":[0,1,2]}", model.toJson());
+        assertThat("value", equalTo(model.get("$child.key")));
+        assertThat(1, equalTo(model.get("$items[1]")));
+        assertThat("{\"child\":{\"key\":\"value\"},\"items\":[0,1,2]}", equalTo(model.toJson()));
     }
 
 
@@ -105,7 +105,6 @@ public class JsonModelTest {
     public void invalid_path_throws() throws Exception {
         JsonModel.model(DOCUMENT).get("store.invalid");
     }
-
 
 
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonPathFilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonPathFilterTest.java
@@ -1,6 +1,8 @@
 package com.jayway.jsonpath;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -10,7 +12,9 @@ import java.util.regex.Pattern;
 import static com.jayway.jsonpath.Criteria.where;
 import static com.jayway.jsonpath.Filter.filter;
 import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 
 /**
  * Created by IntelliJ IDEA.
@@ -18,8 +22,10 @@ import static junit.framework.Assert.assertEquals;
  * Date: 3/5/12
  * Time: 4:24 PM
  */
+@SuppressWarnings("unchecked")
 public class JsonPathFilterTest {
-    
+    private static final Logger logger = LoggerFactory.getLogger(JsonPathFilterTest.class);
+
     public final static String DOCUMENT =
             "{ \"store\": {\n" +
                     "    \"book\": [ \n" +
@@ -55,8 +61,7 @@ public class JsonPathFilterTest {
                     "  }\n" +
                     "}";
 
-    
-    
+
     @Test
     public void arrays_of_maps_can_be_filtered() throws Exception {
 
@@ -87,42 +92,41 @@ public class JsonPathFilterTest {
         root.put("children", asList(rootChild_A, rootChild_B, rootChild_C));
 
 
-
         Filter customFilter = new Filter.FilterAdapter<Map<String, Object>>() {
             @Override
             public boolean accept(Map<String, Object> map) {
-                if(map.get("name").equals("rootGrandChild_A")){
+                if (map.get("name").equals("rootGrandChild_A")) {
                     return true;
                 }
                 return false;
             }
         };
-        
+
         Filter rootChildFilter = filter(where("name").regex(Pattern.compile("rootChild_[A|B]")));
         Filter rootGrandChildFilter = filter(where("name").regex(Pattern.compile("rootGrandChild_[A|B]")));
 
         List read = JsonPath.read(root, "children[?].children[?][?]", rootChildFilter, rootGrandChildFilter, customFilter);
 
 
-        System.out.println(read.size());
+        logger.debug("Size {}", read.size());
     }
-    
-    
+
+
     @Test
     public void arrays_of_objects_can_be_filtered() throws Exception {
         Map<String, Object> doc = new HashMap<String, Object>();
         doc.put("items", asList(1, 2, 3));
-        
-        Filter customFilter = new Filter.FilterAdapter<Integer>(){
+
+        Filter customFilter = new Filter.FilterAdapter<Integer>() {
             @Override
             public boolean accept(Integer o) {
                 return 1 == o;
             }
         };
-        
+
         List<Integer> res = JsonPath.read(doc, "$.items[?]", customFilter);
 
-        assertEquals(1, res.get(0).intValue());
+        assertThat(1, equalTo(res.get(0)));
     }
-    
+
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonPathTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonPathTest.java
@@ -2,6 +2,8 @@ package com.jayway.jsonpath;
 
 import com.jayway.jsonpath.util.ScriptEngineJsonPath;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -17,6 +19,7 @@ import static org.junit.Assert.*;
  * Time: 3:07 PM
  */
 public class JsonPathTest {
+    private static final Logger logger = LoggerFactory.getLogger(JsonPathTest.class);
 
     public final static String ARRAY = "[{\"value\": 1},{\"value\": 2}, {\"value\": 3},{\"value\": 4}]";
 
@@ -51,7 +54,7 @@ public class JsonPathTest {
                     "      \"display-price\": 19.95,\n" +
                     "      \"foo:bar\": \"fooBar\",\n" +
                     "      \"dot.notation\": \"new\",\n" +
-	                "      \"dash-notation\": \"dashes\"\n" +
+                    "      \"dash-notation\": \"dashes\"\n" +
                     "    }\n" +
                     "  }\n" +
                     "}";
@@ -82,8 +85,8 @@ public class JsonPathTest {
     @Test
     public void bracket_notation_can_be_used_in_path() throws Exception {
 
-        //System.out.println(ScriptEngineJsonPath.eval(DOCUMENT, "$.['store'].['bicycle'].['dot.notation']"));
-        System.out.println(ScriptEngineJsonPath.eval(DOCUMENT, "$.store.bicycle.['dot.notation']"));
+        //logger.debug(ScriptEngineJsonPath.eval(DOCUMENT, "$.['store'].['bicycle'].['dot.notation']"));
+        logger.debug(ScriptEngineJsonPath.eval(DOCUMENT, "$.store.bicycle.['dot.notation']"));
 
 
         assertEquals("new", JsonPath.read(DOCUMENT, "$.['store'].bicycle.['dot.notation']"));
@@ -91,12 +94,12 @@ public class JsonPathTest {
         assertEquals("new", JsonPath.read(DOCUMENT, "$.['store']['bicycle']['dot.notation']"));
         assertEquals("new", JsonPath.read(DOCUMENT, "$.['store'].['bicycle'].['dot.notation']"));
 
-	    System.out.println(ScriptEngineJsonPath.eval(DOCUMENT, "$.store.bicycle.['dash-notation']"));
+        logger.debug(ScriptEngineJsonPath.eval(DOCUMENT, "$.store.bicycle.['dash-notation']"));
 
-	    assertEquals("dashes", JsonPath.read(DOCUMENT, "$.['store'].bicycle.['dash-notation']"));
-	    assertEquals("dashes", JsonPath.read(DOCUMENT, "$['store']['bicycle']['dash-notation']"));
-	    assertEquals("dashes", JsonPath.read(DOCUMENT, "$.['store']['bicycle']['dash-notation']"));
-	    assertEquals("dashes", JsonPath.read(DOCUMENT, "$.['store'].['bicycle'].['dash-notation']"));
+        assertEquals("dashes", JsonPath.read(DOCUMENT, "$.['store'].bicycle.['dash-notation']"));
+        assertEquals("dashes", JsonPath.read(DOCUMENT, "$['store']['bicycle']['dash-notation']"));
+        assertEquals("dashes", JsonPath.read(DOCUMENT, "$.['store']['bicycle']['dash-notation']"));
+        assertEquals("dashes", JsonPath.read(DOCUMENT, "$.['store'].['bicycle'].['dash-notation']"));
     }
 
     @Test
@@ -104,7 +107,7 @@ public class JsonPathTest {
         List<Object> matches = JsonPath.read(ARRAY, "$.[?(@.value == 1)]");
 
         assertEquals(1, matches.size());
-        System.out.println(matches);
+        logger.debug(matches.toString());
     }
 
     @Test
@@ -112,7 +115,7 @@ public class JsonPathTest {
         Integer matches = JsonPath.read(ARRAY, "$.[1].value");
 
         assertEquals(new Integer(2), matches);
-        System.out.println(matches);
+        logger.debug(matches.toString());
     }
 
     @Test
@@ -205,7 +208,7 @@ public class JsonPathTest {
 
         assertThat(JsonPath.<List<String>>read(DOCUMENT, "$.store.book[?(@.isbn)].isbn"), hasItems("0-553-21311-3", "0-395-19395-8"));
         assertTrue(JsonPath.<List>read(DOCUMENT, "$.store.book[?(@.isbn)].isbn").size() == 2);
-	    assertTrue(JsonPath.<List>read(DOCUMENT, "$.store.book[?(@['isbn'])].isbn").size() == 2);
+        assertTrue(JsonPath.<List>read(DOCUMENT, "$.store.book[?(@['isbn'])].isbn").size() == 2);
     }
 
     @Test
@@ -217,15 +220,15 @@ public class JsonPathTest {
 
     }
 
-        @Test
+    @Test
     public void all_books() throws Exception {
 
-            //List<String> books = JsonPath.<List<String>>read(DOCUMENT, "$..book");
-            Object books = JsonPath.<List<String>>read(DOCUMENT, "$..book");
+        //List<String> books = JsonPath.<List<String>>read(DOCUMENT, "$..book");
+        Object books = JsonPath.<List<String>>read(DOCUMENT, "$..book");
 
-            System.out.println("test");
+        logger.debug("test");
 
-        }
+    }
 
     @Test
     public void dot_in_predicate_works() throws Exception {
@@ -260,7 +263,6 @@ public class JsonPathTest {
         Object res = JsonPath.read(DOCUMENT, "$.store.book[100].author");
 
     }
-
 
 
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonProviderTest.java
@@ -3,6 +3,8 @@ package com.jayway.jsonpath;
 import com.jayway.jsonpath.spi.impl.JacksonProvider;
 import org.apache.commons.lang.SerializationUtils;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 
@@ -15,6 +17,7 @@ import static com.jayway.jsonpath.JsonModel.model;
  * Time: 10:40 PM
  */
 public class JsonProviderTest {
+    private static final Logger logger = LoggerFactory.getLogger(JsonPathTest.class);
 
     public final static String ARRAY = "[{\"value\": 1},{\"value\": 2}, {\"value\": 3},{\"value\": 4}]";
 
@@ -54,7 +57,6 @@ public class JsonProviderTest {
                     "}";
 
 
-
     @Test
     public void clone_test() throws Exception {
 
@@ -62,7 +64,7 @@ public class JsonProviderTest {
 
         Object clone = SerializationUtils.clone(jsonObject);
 
-        System.out.println(model(clone).toJson());
+        logger.debug(model(clone).toJson());
 
     }
 
@@ -74,7 +76,7 @@ public class JsonProviderTest {
 
         Object o = provider.parse(DOCUMENT);
 
-        System.out.println(o);
+        logger.debug("{}", o);
 
     }
 
@@ -84,6 +86,6 @@ public class JsonProviderTest {
 
         Object o = provider.parse(ARRAY);
 
-        System.out.println(o);
+        logger.debug("{}", o);
     }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/PathTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PathTest.java
@@ -3,6 +3,8 @@ package com.jayway.jsonpath;
 import com.jayway.jsonpath.internal.PathTokenizer;
 import org.hamcrest.Matcher;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.*;
@@ -14,8 +16,9 @@ import static org.junit.Assert.*;
  * Time: 1:22 PM
  */
 public class PathTest {
+    private static final Logger logger = LoggerFactory.getLogger(PathTest.class);
 
-    Filter filter = new Filter(){
+    Filter filter = new Filter() {
         @Override
         public boolean accept(Object obj) {
             return true;
@@ -26,7 +29,7 @@ public class PathTest {
             return this;
         }
     };
-    
+
     @Test
     public void path_is_not_definite() throws Exception {
         assertFalse(JsonPath.compile("$..book[0]").isPathDefinite());
@@ -99,12 +102,12 @@ public class PathTest {
         assertPath("$..book[  ?(@.price<10)]", hasItems("$", "..", "book", "[?(@.price<10)]"));
     }
 
-	@Test
-	public void dot_ending_ignored() throws Exception {
+    @Test
+    public void dot_ending_ignored() throws Exception {
 
-		assertPath("$..book['something'].", hasItems("$", "..", "something"));
+        assertPath("$..book['something'].", hasItems("$", "..", "something"));
 
-	}
+    }
 
     @Test
     public void invalid_path_throws_exception() throws Exception {
@@ -122,20 +125,21 @@ public class PathTest {
         try {
             PathTokenizer tokenizer = new PathTokenizer(path);
             assertTrue("Expected exception!", false);
-        } catch (InvalidPathException expected) {}
+        } catch (InvalidPathException expected) {
+        }
     }
 
     private void assertPath(String path, Matcher<Iterable<String>> matcher) {
-        System.out.println("PATH: " + path);
+        logger.debug("PATH: " + path);
 
         PathTokenizer tokenizer = new PathTokenizer(path);
 
         for (String fragment : tokenizer.getFragments()) {
-            System.out.println(fragment);
+            logger.debug(fragment);
         }
 
         assertThat(tokenizer.getFragments(), matcher);
-        System.out.println("----------------------------------");
+        logger.debug("----------------------------------");
     }
 
 

--- a/json-path/src/test/resources/logback-test.xml
+++ b/json-path/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%.-1level|%-25.25logger{0}| %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.jayway" level="debug"/>
+
+    <root level="warn">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -14,24 +14,25 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+           http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>5</version>
-    </parent>
+
     <groupId>com.jayway.jsonpath</groupId>
     <artifactId>json-path-parent</artifactId>
-    <packaging>pom</packaging>
     <version>0.8.2-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
     <url>https://github.com/jayway/JsonPath</url>
     <name>json-path-parent-pom</name>
+
     <description>Java JsonPath implementation</description>
     <inceptionYear>2011</inceptionYear>
     <issueManagement>
         <system>GitHub Issue Tracking</system>
-        <url />
+        <url/>
     </issueManagement>
     <licenses>
         <license>
@@ -39,6 +40,7 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
+
     <developers>
         <developer>
             <name>Kalle Stenflo</name>
@@ -51,76 +53,248 @@
                 <role>Developer</role>
             </roles>
         </developer>
+        <developer>
+            <name>Gordon Dickens</name>
+            <id>gordon.dickens</id>
+            <organization/>
+            <organizationUrl>http://www.gordondickens.com</organizationUrl>
+            <email>gordon at gordondickens.com</email>
+            <timezone>-5</timezone>
+            <roles>
+                <role>Minion</role>
+            </roles>
+        </developer>
     </developers>
-    <properties>
-        <scm.branch>master</scm.branch>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
     <scm>
         <url>http://github.com/jayway/JsonPath/tree/${scm.branch}</url>
         <connection>scm:git:git://github.com/jayway/JsonPath.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jayway/JsonPath.git</developerConnection>
     </scm>
-
     <mailingLists>
         <mailingList>
             <name>JsonPath mailing-list</name>
-            <archive>http://groups.google.com/group/json-path/topics</archive>
+            <archive>https://groups.google.com/forum/?fromgroups#!forum/jsonpath</archive>
         </mailingList>
     </mailingLists>
+
+    <properties>
+        <commons-lang.version>2.6</commons-lang.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <java.version>1.6</java.version>
+        <jackson.version>1.9.11</jackson.version>
+        <json-smart.version>1.1.1</json-smart.version>
+        <junit.version>4.11</junit.version>
+        <logback.version>1.0.9</logback.version>
+        <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
+        <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
+        <maven-cobertura-plugin.version>2.5.2</maven-cobertura-plugin.version>
+        <maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>2.6</maven-dependency-plugin.version>
+        <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
+        <maven-doxia.version>1.3</maven-doxia.version>
+        <maven-eclipse-plugin.version>2.9</maven-eclipse-plugin.version>
+        <maven-enforcer-plugin.version>1.2</maven-enforcer-plugin.version>
+        <maven-findbugs-plugin.version>2.5.2</maven-findbugs-plugin.version>
+        <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
+        <maven-install-plugin.version>2.4</maven-install-plugin.version>
+        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>2.9</maven-javadoc-plugin.version>
+        <maven-jxr-plugin.version>2.3</maven-jxr-plugin.version>
+        <maven-m2e-lifecycle-plugin.version>1.0.0</maven-m2e-lifecycle-plugin.version>
+        <maven-plugin-plugin.version>3.2</maven-plugin-plugin.version>
+        <maven-project-info-reports-plugin.version>2.6</maven-project-info-reports-plugin.version>
+        <maven-release-plugin.version>2.3.2</maven-release-plugin.version>
+        <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
+        <maven-site-plugin.version>3.2</maven-site-plugin.version>
+        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.12.4</maven-surefire-plugin.version>
+        <maven.version.range>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</maven.version.range>
+        <maven-versions-plugin.version>2.0</maven-versions-plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <scm.branch>master</scm.branch>
+        <slf4j.version>1.7.2</slf4j.version>
+        <wtp.version>2.0</wtp.version>
+    </properties>
 
     <modules>
         <module>json-path</module>
         <module>json-path-assert</module>
     </modules>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <optional>true</optional>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
-        <pluginManagement>
-            <plugins>
-                <!--
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.apache.maven.plugins</groupId>
-						                <artifactId>maven-dependency-plugin</artifactId>
-										<versionRange>[2.1,)</versionRange>
-										<goals>
-											<goal>copy-dependencies</goal>
-											<goal>unpack</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-				-->
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <!--<debug>true</debug>-->
+                    <!--<verbose>true</verbose>-->
+                    <!--<compilerArgument>-Xlint:all</compilerArgument>-->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>${maven-clean-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>${maven-install-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven-plugin-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.1</version>
+                <version>${maven-dependency-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -136,37 +310,175 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                         </configuration>
                     </execution>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>sources</goal>
+                        </goals>
+                    </execution>
                 </executions>
+                <configuration>
+                    <verbose>true</verbose>
+                </configuration>
             </plugin>
-            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>attach-javadocs</id>
+                        <id>enforce-banned-dependencies</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>enforce</goal>
                         </goals>
+                        <configuration>
+                            <rules>
+                                <DependencyConvergence/>
+                                <bannedDependencies>
+                                    <searchTransitive>true</searchTransitive>
+                                    <excludes>
+                                        <exclude>javassist:javassist</exclude>
+                                        <exclude>commons-logging</exclude>
+                                        <exclude>asm:asm*</exclude>
+                                        <exclude>log4j:log4j</exclude>
+                                        <exclude>org.slf4j:1.5*</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                                <requireMavenVersion>
+                                    <version>${maven.version.range}</version>
+                                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and
+                                        checksums respectively.
+                                    </message>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.version}</version>
+                                </requireJavaVersion>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <version>${maven-eclipse-plugin.version}</version>
+                <configuration>
+                    <downloadSources>true</downloadSources>
+                    <downloadJavadocs>true</downloadJavadocs>
+                    <wtpversion>${wtp.version}</wtpversion>
+                    <additionalBuildcommands>
+                        <buildCommand>
+                            <name>org.springframework.ide.eclipse.core.springbuilder</name>
+                            <name>org.eclipse.m2e.core.maven2Builder</name>
+                        </buildCommand>
+                    </additionalBuildcommands>
+                    <additionalProjectnatures>
+                        <projectnature>org.eclipse.jdt.core.javanature</projectnature>
+                        <projectnature>org.springframework.ide.eclipse.core.springnature</projectnature>
+                        <projectnature>org.eclipse.m2e.core.maven2Nature</projectnature>
+                    </additionalProjectnatures>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${maven-site-plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>attach-sources</id>
+                        <id>attach-descriptor</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>attach-descriptor</goal>
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <reportPlugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-report-plugin</artifactId>
+                            <version>${maven-surefire-plugin.version}</version>
+                            <configuration>
+                                <outputDirectory>${project.reporting.outputDirectory}/testresults
+                                </outputDirectory>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <version>${maven-javadoc-plugin.version}</version>
+                            <configuration>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-project-info-reports-plugin</artifactId>
+                            <version>${maven-project-info-reports-plugin.version}</version>
+                            <configuration>
+                                <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                                <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-jxr-plugin</artifactId>
+                            <version>${maven-jxr-plugin.version}</version>
+                            <configuration>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>findbugs-maven-plugin</artifactId>
+                            <version>${maven-findbugs-plugin.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>cobertura-maven-plugin</artifactId>
+                            <version>${maven-cobertura-plugin.version}</version>
+                            <configuration>
+                                <aggregate>true</aggregate>
+                                <outputDirectory>%{project.reporting.outputDirectory}/cobertura</outputDirectory>
+                            </configuration>
+                        </plugin>
+                    </reportPlugins>
+                </configuration>
             </plugin>
-            -->
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <!-- N.B. Lifecycle mapping is not a real plugin, it is to support Eclipse Foundation's M2E plugin -->
+                <!--
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>[2.1,)</versionRange>
+                                        <goals>
+                                            <goal>copy-dependencies</goal>
+                                            <goal>unpack</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+                -->
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>
@@ -177,7 +489,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.7</version>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -190,7 +502,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.1.2</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -200,51 +511,22 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
-
-    <dependencyManagement>
-        <dependencies>
-
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>1.1.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <optional>true</optional>
-                <version>1.9.5</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>1.2.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>1.2.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.10</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>


### PR DESCRIPTION
- Changes from Gordon Dickens
- Removed dependency on sonatype parent project
- Added explicit versions for standard plugins
- Added logging for tests, replacing sysout
- Removed unnecessary boxing/unboxing of primitives
- Added @Unchecked for test classes
- Refactored out deprecated JUnit packages "junit.framework", replacing with Hamcrest matchers or "org.junit"
- Added Maven Site Reporting
  - run "mvn site"
  - open "target/site/index.html"
- NOTES:
  - net.minidev:json-smart - is NOT OSGi compliant
  - HttpProviderTest - refactor out sun.misc.IOUtils, its an internal proprietary API and may be removed in a future release
  - JsonAssert.mapContainingKey() contains unchecked assignment, can this be improved?
