### PR TITLE
We need some means to plug in a different JSON parser/provider 

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/spi/JsonProviderFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/JsonProviderFactory.java
@@ -21,10 +21,23 @@ import com.jayway.jsonpath.spi.impl.JsonSmartJsonProvider;
  */
 public abstract class JsonProviderFactory {
 
+	private static Class defaultProvider = null;
+	
     public static JsonProviderFactory factory = new JsonProviderFactory() {
         @Override
         protected JsonProvider create() {
-            return new JsonSmartJsonProvider();
+			JsonProvider provider = null;
+			try {
+				if(defaultProvider != null) {
+					provider = (JsonProvider)defaultProvider.newInstance();
+				}
+			} catch(Throwable t) {
+			
+			}
+			if(provider == null) {
+				provider = new JsonSmartJsonProvider();
+			}
+			return provider;
             //return new JacksonProvider();
         }
     };
@@ -33,6 +46,9 @@ public abstract class JsonProviderFactory {
         return factory.create();
     }
 
+    public static synchronized void setDefaultProvider(Class<? extends JsonProvider> jsonProvider) {
+        defaultProvider = jsonProvider;
+    }
 
     protected abstract JsonProvider create();
 


### PR DESCRIPTION
Updated the JsonProviderFactory to set the default JSON parser/provider. The implementation will fall back to JsonSmartJsonProvider if the provider is not defined. 
