### PR TITLE
Underlying net.minidev.json.parser.JsonParser is not threadsafe

### DIFF
--- a/json-path-assert/src/main/java/com/jayway/jsonassert/JsonAssert.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/JsonAssert.java
@@ -19,13 +19,6 @@ import java.util.Map;
  */
 public class JsonAssert {
 
-    private static JsonProvider jsonProvider = JsonProviderFactory.createProvider();
-
-    public static void setJsonProvider(JsonProvider jsonProvider) {
-        JsonAssert.jsonProvider = jsonProvider;
-    }
-
-
     /**
      * Creates a JSONAsserter
      *
@@ -34,7 +27,7 @@ public class JsonAssert {
      * @throws ParseException when the given JSON could not be parsed
      */
     public static JsonAsserter with(String json) {
-        return new JsonAsserterImpl(jsonProvider.parse(json));
+        return new JsonAsserterImpl(JsonProviderFactory.createProvider().parse(json));
     }
 
     /**
@@ -45,7 +38,7 @@ public class JsonAssert {
      * @throws ParseException when the given JSON could not be parsed
      */
     public static JsonAsserter with(Reader reader) throws IOException {
-        return new JsonAsserterImpl(jsonProvider.parse(convertReaderToString(reader)));
+        return new JsonAsserterImpl(JsonProviderFactory.createProvider().parse(convertReaderToString(reader)));
 
     }
 


### PR DESCRIPTION
I'm occasionally seeing this error running tests in parallell with maven surefire:

java.lang.RuntimeException: Internal Error
    at net.minidev.json.parser.JSONParserBase.readArray(JSONParserBase.java:237)
    at net.minidev.json.parser.JSONParserBase.readMain(JSONParserBase.java:306)
    at net.minidev.json.parser.JSONParserBase.readObject(JSONParserBase.java:442)
    at net.minidev.json.parser.JSONParserBase.readMain(JSONParserBase.java:303)
    at net.minidev.json.parser.JSONParserBase.parse(JSONParserBase.java:154)
    at net.minidev.json.parser.JSONParserString.parse(JSONParserString.java:55)
    at net.minidev.json.parser.JSONParserString.parse(JSONParserString.java:37)
    at net.minidev.json.parser.JSONParser.parse(JSONParser.java:135)
    at com.jayway.jsonpath.spi.impl.JsonSmartJsonProvider.parse(JsonSmartJsonProvider.java:58)
    at com.jayway.jsonassert.JsonAssert.with(JsonAssert.java:37)

As far as I can see the net.minidev.json.parser.JSONParser isn't thread-safe so the assertions shouldn't use the same parser instance.
