### PR TITLE
Support for Boolean values in ExpressionEvaluator 

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/eval/ExpressionEvaluator.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/eval/ExpressionEvaluator.java
@@ -90,6 +90,15 @@ public class ExpressionEvaluator {
             } else if ("!=".equals(comparator) || "<>".equals(comparator)) {
                 return !a.equals(expected);
             }
+        } else if (actual instanceof Boolean) {
+
+            Boolean a = (Boolean) actual;
+            Boolean e = Boolean.valueOf(expected);
+            if ("==".equals(comparator)) {
+                return a.equals(e);
+            } else if ("!=".equals(comparator) || "<>".equals(comparator)) {
+                return !a.equals(e);
+            }
         }
 
         return false;

--- a/json-path/src/test/java/com/jayway/jsonpath/ExpressionEvalTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/ExpressionEvalTest.java
@@ -60,5 +60,23 @@ public class ExpressionEvalTest {
 
     }
 
+    @Test
+    public void boolean_eval() throws Exception {
+
+        assertTrue(ExpressionEvaluator.eval(true, "==", "true"));
+        assertTrue(ExpressionEvaluator.eval(false, "==", "false"));
+        assertTrue(ExpressionEvaluator.eval(true, "!=", "false"));
+        assertTrue(ExpressionEvaluator.eval(true, "<>", "false"));
+        assertTrue(ExpressionEvaluator.eval(false, "!=", "true"));
+        assertTrue(ExpressionEvaluator.eval(false, "<>", "true"));
+
+        assertFalse(ExpressionEvaluator.eval(true, "==", "false"));
+        assertFalse(ExpressionEvaluator.eval(false, "==", "true"));
+        assertFalse(ExpressionEvaluator.eval(true, "!=", "true"));
+        assertFalse(ExpressionEvaluator.eval(true, "<>", "true"));
+        assertFalse(ExpressionEvaluator.eval(false, "!=", "false"));
+        assertFalse(ExpressionEvaluator.eval(false, "<>", "false"));
+
+    }
 
 }


### PR DESCRIPTION
Currently ExpressionEvaluator fails to evalute jsonPath expression $.foo[?(@.bar == true)] for json {"foo": {"name": "foo", "bar": "true"}}.
This commit fixes that.
