### PR TITLE
Fix a NPE when the expected array is actually null

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ArrayIndexFilter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ArrayIndexFilter.java
@@ -61,7 +61,7 @@ public class ArrayIndexFilter extends PathTokenFilter {
         } else {
             String[] indexArr = trimmedCondition.split(",");
 
-            if(src.isEmpty()){
+            if(src == null || src.isEmpty()){
                 return result;
             }
 


### PR DESCRIPTION
Don't crash with a NPE when the expected array is actually null, just return null.

``` json
{
  "success": true,
  "data": {
    "user": 3,
    "own": null,
    "passes": null,
    "completed": null
  },
  "version": 1371160528774
}
```

Without this fix, the path `$.data.passes[0].id` gets a NPE.
