### PR TITLE
print path, add custom message in assert

### DIFF
--- a/json-path-assert/src/main/java/com/jayway/jsonassert/JsonAsserter.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/JsonAsserter.java
@@ -27,6 +27,15 @@ public interface JsonAsserter {
     <T> JsonAsserter assertThat(String path, Matcher<T> matcher);
 
     /**
+     * @param path
+     * @param matcher
+     * @param message
+     * @param <T>
+     * @return
+     */
+    <T> JsonAsserter assertThat(String path, Matcher<T> matcher, String message);
+
+    /**
      * Asserts that object specified by path is equal to the expected value.
      * If they are not, an AssertionError is thrown with the given message.
      *
@@ -37,6 +46,8 @@ public interface JsonAsserter {
      */
     <T> JsonAsserter assertEquals(String path, T expected);
 
+    <T> JsonAsserter assertEquals(String path, T expected, String message);
+
     /**
      * Checks that a path is not defined within a document. If the document contains the
      * given path, an AssertionError is thrown
@@ -45,6 +56,8 @@ public interface JsonAsserter {
      * @return this
      */
     JsonAsserter assertNotDefined(String path);
+
+    JsonAsserter assertNotDefined(String path, String message);
 
 
     /**
@@ -55,6 +68,7 @@ public interface JsonAsserter {
      * @return this to allow fluent assertion chains
      */
     JsonAsserter assertNull(String path);
+    JsonAsserter assertNull(String path, String message);
 
     /**
      * Asserts that object specified by path is NOT null. If it is, an AssertionError
@@ -64,6 +78,8 @@ public interface JsonAsserter {
      * @return this to allow fluent assertion chains
      */
     <T> JsonAsserter assertNotNull(String path);
+
+    <T> JsonAsserter assertNotNull(String path, String message);
 
     /**
      * Syntactic sugar to allow chaining assertions with a separating and() statement

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
@@ -38,7 +38,19 @@ public class JsonAsserterImpl implements JsonAsserter {
         T obj = JsonPath.<T>read(jsonObject, path);
         if (!matcher.matches(obj)) {
 
-            throw new AssertionError(String.format("JSON doesn't match.\nExpected:\n%s\nActual:\n%s", matcher.toString(), obj));
+            throw new AssertionError(String.format("JSON path [%s] doesn't match.\nExpected:\n%s\nActual:\n%s", path, matcher.toString(), obj));
+        }
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> JsonAsserter assertThat(String path, Matcher<T> matcher, String message) {
+        T obj = JsonPath.<T>read(jsonObject, path);
+        if (!matcher.matches(obj)) {
+            throw new AssertionError(String.format("JSON Assert Error: %s\nExpected:\n%s\nActual:\n%s", message, matcher.toString(), obj));
         }
         return this;
     }
@@ -63,6 +75,16 @@ public class JsonAsserterImpl implements JsonAsserter {
         return this;
     }
 
+    @Override
+    public JsonAsserter assertNotDefined(String path, String message) {
+        try {
+            Object o = JsonPath.read(jsonObject, path);
+            throw new AssertionError(format("Document contains the path <%s> but was expected not to.", path));
+        } catch (InvalidPathException e) {
+        }
+        return this;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -70,11 +92,26 @@ public class JsonAsserterImpl implements JsonAsserter {
         return assertThat(path, nullValue());
     }
 
+    @Override
+    public JsonAsserter assertNull(String path, String message) {
+        return assertThat(path, nullValue(), message);
+    }
+
+    @Override
+    public <T> JsonAsserter assertEquals(String path, T expected, String message) {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
     /**
      * {@inheritDoc}
      */
     public <T> JsonAsserter assertNotNull(String path) {
         return assertThat(path, notNullValue());
+    }
+
+    @Override
+    public <T> JsonAsserter assertNotNull(String path, String message) {
+        return assertThat(path, notNullValue(), message);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.jayway.jsonpath</groupId>
     <artifactId>json-path-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.8.2-SNAPSHOT</version>
+    <version>0.8.1-HBO</version>
     <url>https://github.com/jayway/JsonPath</url>
     <name>json-path-parent-pom</name>
     <description>Java JsonPath implementation</description>


### PR DESCRIPTION
in asserts, the failure (default) messaging is inadequate. It doesnot
even print the path that failed. this path should help eloberate the
messaging
