### PR TITLE
allow to filter for existence of nested properties

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterFactory.java
@@ -64,7 +64,7 @@ public class FilterFactory {
                     return new ArrayEvalFilter(pathFragment);
                 } else if (!pathFragment.contains("=") && !pathFragment.contains("<") && !pathFragment.contains(">")) {
                     //[?(@.isbn)]
-                    return new HasFieldFilter(pathFragment);
+                    return new HasPathFilter(pathFragment);
                 } else {
                     throw new InvalidPathException("Failed to create PathTokenFilter for path fragment: " + pathFragment);
                 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JsonPathTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JsonPathTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 /**
@@ -316,6 +317,12 @@ public class JsonPathTest {
     }
 
 
+    @Test
+    public void exists_filter_with_nested_path() throws Exception {
 
+        assertThat(JsonPath.<List<String>>read(DOCUMENT, "$..[?(@.bicycle.color)]"), hasSize(1));
+        assertThat(JsonPath.<List<String>>read(DOCUMENT, "$..[?(@.bicycle.numberOfGears)]"), hasSize(0));
+
+    }
 
 }


### PR DESCRIPTION
Currently, you cannot filter for the existence of nested properties, e.g. `$..[?(@.bicycle.color)]`. This patch renames the (internal) `HasFieldFilter` to `HasPathFilter` and interprets the filter expression as a path.
