### PR TITLE
This PR fixes compile issue (non-existent import) and adds some tests

### DIFF
--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
@@ -13,9 +13,7 @@ import static org.hamcrest.Matchers.*;
 
 public class JsonAsserterImpl implements JsonAsserter {
 
-
     private final Object jsonObject;
-
 
     /**
      * Instantiates a new JSONAsserter
@@ -26,13 +24,19 @@ public class JsonAsserterImpl implements JsonAsserter {
         this.jsonObject = jsonObject;
     }
 
-
     /**
      * {@inheritDoc}
      */
     @SuppressWarnings("unchecked")
     public <T> JsonAsserter assertThat(String path, Matcher<T> matcher) {
-        T obj = JsonPath.<T>read(jsonObject, path);
+        T obj = null;
+        
+        try {
+            obj = JsonPath.<T>read(jsonObject, path);
+        } catch (Exception e) {
+            throw new AssertionError(String.format("Error reading JSON path [%s]", path), e);
+        }
+
         if (!matcher.matches(obj)) {
 
             throw new AssertionError(String.format("JSON path [%s] doesn't match.\nExpected:\n%s\nActual:\n%s", path, matcher.toString(), obj));

--- a/json-path-assert/src/test/java/com/jayway/jsonassert/JsonAssertTest.java
+++ b/json-path-assert/src/test/java/com/jayway/jsonassert/JsonAssertTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 
 import java.io.InputStream;
 
+import com.jayway.jsonpath.PathNotFoundException;
+
 import static com.jayway.jsonassert.JsonAssert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -44,7 +46,7 @@ public class JsonAssertTest {
                     "  }\n" +
                     "}";
 
-    @Test
+    @Test(expected = AssertionError.class)
     public void invalid_path() throws Exception {
         with(JSON).assertThat("$.store.book[*].fooBar", collectionWithSize(equalTo(4)));
     }
@@ -65,7 +67,6 @@ public class JsonAssertTest {
                 .assertThat("rows", collectionWithSize(equalTo(2)));
 
     }
-
 
     @Test
     //@Ignore //TODO: finalize behaviour
@@ -148,8 +149,6 @@ public class JsonAssertTest {
     }
     */
 
-
-
     @Test
     public void path_including_wildcard_path_followed_by_another_path_concatenates_results_to_list() throws Exception {
         with(getResourceAsStream("lotto.json")).assertThat("lotto.winners[*].winnerId", hasItems(23, 54));
@@ -164,7 +163,20 @@ public class JsonAssertTest {
         asserter.assertNotDefined("$xxx"); // fail  but should be pass
     }
 
+    @Test
+    public void testAssertEqualsInteger() throws Exception {
+        with(getResourceAsStream("lotto.json")).assertEquals("lotto.winners[0].winnerId", 23);
+    }
 
+    @Test(expected = AssertionError.class)
+    public void testAssertEqualsIntegerInvalidExpected() throws Exception {
+        with(getResourceAsStream("lotto.json")).assertEquals("lotto.winners[0].winnerId", 24);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testAssertEqualsIntegerInvalidField() throws Exception {
+        with(getResourceAsStream("lotto.json")).assertEquals("lotto.winners[0].winnerId1", 24);
+    }
 
     private InputStream getResourceAsStream(String resourceName) {
         return getClass().getClassLoader().getResourceAsStream(resourceName);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/Utils.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/Utils.java
@@ -1,7 +1,5 @@
 package com.jayway.jsonpath.internal;
 
-import com.jayway.jsonpath.InvalidConversionException;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;


### PR DESCRIPTION
- Add tests for assertEquals() methods with integer arguments, both success and failing cases.
- Altered JsonAsserterImpl.java so that assertEquals() still returns AssertionError when invalid field or other reading exception.
