### PR TITLE
merge JsonProvider's getMapValue methods, various small performance improvements

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/compiler/PathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/compiler/PathToken.java
@@ -69,12 +69,12 @@ public abstract class PathToken {
         }
     }
 
-    private boolean hasProperty(String property, Object model, EvaluationContextImpl ctx) {
+    private static boolean hasProperty(String property, Object model, EvaluationContextImpl ctx) {
         return ctx.jsonProvider().getPropertyKeys(model).contains(property);
     }
 
-    private Object readObjectProperty(String property, Object model, EvaluationContextImpl ctx) {
-        return ctx.jsonProvider().getMapValue(model, property, true);
+    private static Object readObjectProperty(String property, Object model, EvaluationContextImpl ctx) {
+        return ctx.jsonProvider().getMapValue(model, property);
     }
 
     void handleArrayIndex(int index, String currentPath, Object json, EvaluationContextImpl ctx) {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/spi/json/AbstractJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/spi/json/AbstractJsonProvider.java
@@ -50,23 +50,11 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      *
      * @param obj a map
      * @param key property key
-     * @return the map entry
+     * @return the map entry or {@link com.jayway.jsonpath.spi.json.JsonProvider#UNDEFINED} for missing properties
      */
     public Object getMapValue(Object obj, String key){
-        return ((Map) obj).get(key);
-    }
-
-    /**
-     * Extracts a value from an map
-     *
-     * @param obj a map
-     * @param key property key
-     * @param signalUndefined if true the constant {@link com.jayway.jsonpath.spi.json.JsonProvider#UNDEFINED} is returned for missing properties
-     * @return the map entry
-     */
-    public Object getMapValue(Object obj, String key, boolean signalUndefined){
         Map m = (Map) obj;
-        if(!m.containsKey(key) && signalUndefined){
+        if(!m.containsKey(key)){
             return JsonProvider.UNDEFINED;
         } else {
             return m.get(key);

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonProvider.java
@@ -83,19 +83,9 @@ public interface JsonProvider {
      *
      * @param obj a map
      * @param key property key
-     * @return the map entry
+     * @return the map entry or {@link com.jayway.jsonpath.spi.json.JsonProvider#UNDEFINED} for missing properties
      */
     Object getMapValue(Object obj, String key);
-
-    /**
-     * Extracts a value from an map
-     *
-     * @param obj a map
-     * @param key property key
-     * @param signalUndefined if true the constant {@link com.jayway.jsonpath.spi.json.JsonProvider#UNDEFINED} is returned for missing properties
-     * @return the map entry
-     */
-    Object getMapValue(Object obj, String key, boolean signalUndefined);
 
     /**
      * Sets a value in an object or array


### PR DESCRIPTION
I merged the two `getMapValue` methods in the `JsonProvider` interface. The method is now required to return `JsonProvider.UNDEFINED` if the map does not contain the value.
Also, I made some methods static and extracted some classes.
