### PR TITLE
Added ability to get items from the PredicateContext using a TypeRef<T>

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Predicate.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Predicate.java
@@ -39,6 +39,13 @@ public interface Predicate {
         <T> T item(Class<T> clazz) throws MappingException;
 
         /**
+         * Returns the current item being evaluated by this predicate. It will be mapped
+         * to the type of the provided TypeRef
+         * @return current document
+         */
+        <T> T item(TypeRef<T> typeRef) throws MappingException;
+
+        /**
          * Returns the root document (the complete JSON)
          * @return root document
          */

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicateContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/token/PredicateContextImpl.java
@@ -16,6 +16,7 @@ package com.jayway.jsonpath.internal.token;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.TypeRef;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.spi.mapper.MappingException;
 import org.slf4j.Logger;
@@ -67,6 +68,11 @@ public class PredicateContextImpl implements Predicate.PredicateContext {
     @Override
     public <T> T item(Class<T> clazz) throws MappingException {
         return  configuration().mappingProvider().map(contextDocument, clazz, configuration);
+    }
+
+    @Override
+    public <T> T item(TypeRef<T> typeRef) throws MappingException {
+        return configuration().mappingProvider().map(contextDocument, typeRef, configuration);
     }
 
     @Override


### PR DESCRIPTION
Passing a TypeRef to PredicateContext.item(...) makes it possible to get typed lists for use in predicates
A minor change that delegates to the equivalent MappingProvider method
