### PR TITLE
implement subset filter operator, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Filters are logical expressions used to filter arrays. A typical filter would be
 | =~                       | left matches regular expression  [?(@.name =~ /foo.*?/i)]         |
 | in                       | left exists in right [?(@.size in ['S', 'M'])]                    |
 | nin                      | left does not exists in right                                     |
+| subset                   | left is a subset of right [?(@.sizes subset ['S', 'M', 'L'])]     |
 | size                     | size of left (array or string) should match right                 |
 | empty                    | left (array or string) should be empty                            |
 

--- a/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
@@ -268,6 +268,33 @@ public class Criteria implements Predicate {
     }
 
     /**
+     * The <code>subset</code> operator selects objects for which the specified field is
+     * an array whose elements comprise a subset of the set comprised by the elements of
+     * the specified array.
+     *
+     * @param o the values to match against
+     * @return the criteria
+     */
+    public Criteria subset(Object... o) {
+        return subset(Arrays.asList(o));
+    }
+
+    /**
+     * The <code>subset</code> operator selects objects for which the specified field is
+     * an array whose elements comprise a subset of the set comprised by the elements of
+     * the specified array.
+     *
+     * @param c the values to match against
+     * @return the criteria
+     */
+    public Criteria subset(Collection<?> c) {
+        notNull(c, "collection can not be null");
+        this.criteriaType = RelationalOperator.SUBSET;
+        this.right = new ValueNode.ValueListNode(c);
+        return this;
+    }
+
+    /**
      * The <code>all</code> operator is similar to $in, but instead of matching any value
      * in the specified array all values in the array must be matched.
      *

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
@@ -29,6 +29,7 @@ public class EvaluatorFactory {
         evaluators.put(RelationalOperator.CONTAINS, new ContainsEvaluator());
         evaluators.put(RelationalOperator.MATCHES, new PredicateMatchEvaluator());
         evaluators.put(RelationalOperator.TYPE, new TypeEvaluator());
+        evaluators.put(RelationalOperator.SUBSET, new SubsetEvaluator());
     }
 
     public static Evaluator createEvaluator(RelationalOperator operator){
@@ -264,4 +265,34 @@ public class EvaluatorFactory {
             return input;
         }
     }
+
+    private static class SubsetEvaluator implements Evaluator {
+       @Override
+       public boolean evaluate(ValueNode left, ValueNode right, Predicate.PredicateContext ctx) {
+           ValueNode.ValueListNode rightValueListNode;
+           if(right.isJsonNode()){
+               ValueNode vn = right.asJsonNode().asValueListNode(ctx);
+               if(vn.isUndefinedNode()){
+                   return false;
+               } else {
+                   rightValueListNode = vn.asValueListNode();
+               }
+           } else {
+               rightValueListNode = right.asValueListNode();
+           }
+           ValueNode.ValueListNode leftValueListNode;
+           if(left.isJsonNode()){
+               ValueNode vn = left.asJsonNode().asValueListNode(ctx);
+               if(vn.isUndefinedNode()){
+                   return false;
+               } else {
+                  leftValueListNode = vn.asValueListNode();
+               }
+           } else {
+              leftValueListNode = left.asValueListNode();
+           }
+           return leftValueListNode.subset(rightValueListNode);
+       }
+   }
+
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
@@ -29,7 +29,8 @@ public enum RelationalOperator {
     EXISTS("EXISTS"),
     TYPE("TYPE"),
     MATCHES("MATCHES"),
-    EMPTY("EMPTY");
+    EMPTY("EMPTY"),
+    SUBSET("SUBSET");
 
     private final String operatorString;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
@@ -709,6 +709,15 @@ public abstract class ValueNode {
             return nodes.contains(node);
         }
 
+        public boolean subset(ValueListNode right) {
+            for (ValueNode leftNode : nodes) {
+                if (!right.nodes.contains(leftNode)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public List<ValueNode> getNodes() {
             return Collections.unmodifiableList(nodes);
         }


### PR DESCRIPTION
I added the `subset` filter operator.
You can do things like:
`?(@.availableSizes subset ['S', 'M', 'L'])`
or
`?(['S', 'M', 'L'] subset @.availableSizes)`
In order to check for proper subset, for example you could do:
`?(@.availableSizes subset ['S', 'M', 'L'] && !(['S', 'M', 'L'] subset @.availableSizes))`