### PR TITLE
implement subsetof filter operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Filters are logical expressions used to filter arrays. A typical filter would be
 | =~                       | left matches regular expression  [?(@.name =~ /foo.*?/i)]         |
 | in                       | left exists in right [?(@.size in ['S', 'M'])]                    |
 | nin                      | left does not exists in right                                     |
+| subset                   | left is a subset of right [?(@.sizes subset ['S', 'M', 'L'])]     |
 | size                     | size of left (array or string) should match right                 |
 | empty                    | left (array or string) should be empty                            |
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Filters are logical expressions used to filter arrays. A typical filter would be
 | =~                       | left matches regular expression  [?(@.name =~ /foo.*?/i)]         |
 | in                       | left exists in right [?(@.size in ['S', 'M'])]                    |
 | nin                      | left does not exists in right                                     |
-| subset                   | left is a subset of right [?(@.sizes subset ['S', 'M', 'L'])]     |
+| subsetof                 | left is a subset of right [?(@.sizes subsetof ['S', 'M', 'L'])]     |
 | size                     | size of left (array or string) should match right                 |
 | empty                    | left (array or string) should be empty                            |
 

--- a/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
@@ -268,28 +268,28 @@ public class Criteria implements Predicate {
     }
 
     /**
-     * The <code>subset</code> operator selects objects for which the specified field is
+     * The <code>subsetof</code> operator selects objects for which the specified field is
      * an array whose elements comprise a subset of the set comprised by the elements of
      * the specified array.
      *
      * @param o the values to match against
      * @return the criteria
      */
-    public Criteria subset(Object... o) {
-        return subset(Arrays.asList(o));
+    public Criteria subsetof(Object... o) {
+        return subsetof(Arrays.asList(o));
     }
 
     /**
-     * The <code>subset</code> operator selects objects for which the specified field is
+     * The <code>subsetof</code> operator selects objects for which the specified field is
      * an array whose elements comprise a subset of the set comprised by the elements of
      * the specified array.
      *
      * @param c the values to match against
      * @return the criteria
      */
-    public Criteria subset(Collection<?> c) {
+    public Criteria subsetof(Collection<?> c) {
         notNull(c, "collection can not be null");
-        this.criteriaType = RelationalOperator.SUBSET;
+        this.criteriaType = RelationalOperator.SUBSETOF;
         this.right = new ValueNode.ValueListNode(c);
         return this;
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
@@ -268,6 +268,33 @@ public class Criteria implements Predicate {
     }
 
     /**
+     * The <code>subset</code> operator selects objects for which the specified field is
+     * an array whose elements comprise a subset of the set comprised by the elements of
+     * the specified array.
+     *
+     * @param o the values to match against
+     * @return the criteria
+     */
+    public Criteria subset(Object... o) {
+        return subset(Arrays.asList(o));
+    }
+
+    /**
+     * The <code>subset</code> operator selects objects for which the specified field is
+     * an array whose elements comprise a subset of the set comprised by the elements of
+     * the specified array.
+     *
+     * @param c the values to match against
+     * @return the criteria
+     */
+    public Criteria subset(Collection<?> c) {
+        notNull(c, "collection can not be null");
+        this.criteriaType = RelationalOperator.SUBSET;
+        this.right = new ValueNode.ValueListNode(c);
+        return this;
+    }
+
+    /**
      * The <code>all</code> operator is similar to $in, but instead of matching any value
      * in the specified array all values in the array must be matched.
      *

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
@@ -29,6 +29,7 @@ public class EvaluatorFactory {
         evaluators.put(RelationalOperator.CONTAINS, new ContainsEvaluator());
         evaluators.put(RelationalOperator.MATCHES, new PredicateMatchEvaluator());
         evaluators.put(RelationalOperator.TYPE, new TypeEvaluator());
+        evaluators.put(RelationalOperator.SUBSET, new SubsetEvaluator());
     }
 
     public static Evaluator createEvaluator(RelationalOperator operator){
@@ -264,4 +265,34 @@ public class EvaluatorFactory {
             return input;
         }
     }
+
+    private static class SubsetEvaluator implements Evaluator {
+       @Override
+       public boolean evaluate(ValueNode left, ValueNode right, Predicate.PredicateContext ctx) {
+           ValueNode.ValueListNode rightValueListNode;
+           if(right.isJsonNode()){
+               ValueNode vn = right.asJsonNode().asValueListNode(ctx);
+               if(vn.isUndefinedNode()){
+                   return false;
+               } else {
+                   rightValueListNode = vn.asValueListNode();
+               }
+           } else {
+               rightValueListNode = right.asValueListNode();
+           }
+           ValueNode.ValueListNode leftValueListNode;
+           if(left.isJsonNode()){
+               ValueNode vn = left.asJsonNode().asValueListNode(ctx);
+               if(vn.isUndefinedNode()){
+                   return false;
+               } else {
+                  leftValueListNode = vn.asValueListNode();
+               }
+           } else {
+              leftValueListNode = left.asValueListNode();
+           }
+           return leftValueListNode.subset(rightValueListNode);
+       }
+   }
+
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
@@ -29,7 +29,7 @@ public class EvaluatorFactory {
         evaluators.put(RelationalOperator.CONTAINS, new ContainsEvaluator());
         evaluators.put(RelationalOperator.MATCHES, new PredicateMatchEvaluator());
         evaluators.put(RelationalOperator.TYPE, new TypeEvaluator());
-        evaluators.put(RelationalOperator.SUBSET, new SubsetEvaluator());
+        evaluators.put(RelationalOperator.SUBSETOF, new SubsetOfEvaluator());
     }
 
     public static Evaluator createEvaluator(RelationalOperator operator){
@@ -266,7 +266,7 @@ public class EvaluatorFactory {
         }
     }
 
-    private static class SubsetEvaluator implements Evaluator {
+    private static class SubsetOfEvaluator implements Evaluator {
        @Override
        public boolean evaluate(ValueNode left, ValueNode right, Predicate.PredicateContext ctx) {
            ValueNode.ValueListNode rightValueListNode;
@@ -291,7 +291,7 @@ public class EvaluatorFactory {
            } else {
               leftValueListNode = left.asValueListNode();
            }
-           return leftValueListNode.subset(rightValueListNode);
+           return leftValueListNode.subsetof(rightValueListNode);
        }
    }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
@@ -30,7 +30,7 @@ public enum RelationalOperator {
     TYPE("TYPE"),
     MATCHES("MATCHES"),
     EMPTY("EMPTY"),
-    SUBSET("SUBSET");
+    SUBSETOF("SUBSETOF");
 
     private final String operatorString;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
@@ -29,7 +29,8 @@ public enum RelationalOperator {
     EXISTS("EXISTS"),
     TYPE("TYPE"),
     MATCHES("MATCHES"),
-    EMPTY("EMPTY");
+    EMPTY("EMPTY"),
+    SUBSET("SUBSET");
 
     private final String operatorString;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
@@ -714,7 +714,7 @@ public abstract class ValueNode {
             return nodes.contains(node);
         }
 
-        public boolean subset(ValueListNode right) {
+        public boolean subsetof(ValueListNode right) {
             for (ValueNode leftNode : nodes) {
                 if (!right.nodes.contains(leftNode)) {
                     return false;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
@@ -714,6 +714,15 @@ public abstract class ValueNode {
             return nodes.contains(node);
         }
 
+        public boolean subset(ValueListNode right) {
+            for (ValueNode leftNode : nodes) {
+                if (!right.nodes.contains(leftNode)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public List<ValueNode> getNodes() {
             return Collections.unmodifiableList(nodes);
         }

--- a/json-path/src/test/java/com/jayway/jsonpath/FilterParseTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/FilterParseTest.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath;
 
+import java.util.Collections;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -138,6 +139,15 @@ public class FilterParseTest {
 
         String filter = filter(where("a").size(5)).toString();
         String parsed = parse("[?(@['a'] SIZE 5)]").toString();
+
+        assertThat(filter).isEqualTo(parsed);
+    }
+
+    @Test
+    public void a_subsetof_filter_can_be_serialized() {
+
+        String filter = filter(where("a").subsetof(Collections.emptyList())).toString();
+        String parsed = parse("[?(@['a'] SUBSETOF [])]").toString();
 
         assertThat(filter).isEqualTo(parsed);
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
@@ -1,5 +1,7 @@
 package com.jayway.jsonpath;
 
+import java.util.ArrayList;
+import org.assertj.core.util.Lists;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -356,6 +358,24 @@ public class FilterTest extends BaseTest {
     @Test
     public void null_size_evals() {
         assertThat(filter(where("null-key").size(6)).apply(createPredicateContext(json))).isEqualTo(false);
+    }
+
+    //----------------------------------------------------------------------------
+    //
+    // SUBSETOF
+    //
+    //----------------------------------------------------------------------------
+    @Test
+    public void array_subsetof_evals() {
+        // list is a superset
+        List<String> list = Lists.newArrayList("a", "b", "c", "d", "e", "f", "g");
+        assertThat(filter(where("string-arr").subsetof(list)).apply(createPredicateContext(json))).isEqualTo(true);
+        // list is exactly the same set (but in a different order)
+        list = Lists.newArrayList("e", "d", "b", "c", "a");
+        assertThat(filter(where("string-arr").subsetof(list)).apply(createPredicateContext(json))).isEqualTo(true);
+        // list is missing one element
+        list = Lists.newArrayList("a", "b", "c", "d");
+        assertThat(filter(where("string-arr").subsetof(list)).apply(createPredicateContext(json))).isEqualTo(false);
     }
 
     //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR is an extension of #337 updated with reviewer feedback.

- I agree `subsetof` is a better name than `subset` -- it type-checks grammatically against things like `in` or `notin` or `equals`. (though to be fair, `size` and `empty` do not type-check the same way.)
- Added tests, based on the `size` tests.

I included the original commit from the original author.

Please let me know if there is additional work to do to make this ready for merging.

Thanks!