### PR TITLE
Update Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Jayway JsonPath
 
 **A Java DSL for reading JSON documents.**
 
-[![Build Status](https://travis-ci.org/jayway/JsonPath.svg?branch=master)](https://travis-ci.org/jayway/JsonPath)
+[![Build Status](https://travis-ci.org/json-path/JsonPath.svg?branch=master)](https://travis-ci.org/jayway/JsonPath)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jayway.jsonpath/json-path/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jayway.jsonpath/json-path)
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jayway.jsonpath/json-path/badge.svg)](http://www.javadoc.io/doc/com.jayway.jsonpath/json-path)
 


### PR DESCRIPTION
Also, Travis builds need to be enabled for the new repository under the `json-path` namespace. 