### PR TITLE
Issue #191 fixes both $..allTheThings.max() and $.max($..allTheThings)

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
@@ -21,7 +21,6 @@ import java.util.Map;
  * Leverages the function's name in order to determine which function to execute which is maintained internally
  * here via a static map
  *
- * Created by mattg on 6/27/15.
  */
 public class PathFunctionFactory {
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
@@ -48,12 +48,9 @@ public abstract class AbstractAggregation implements PathFunction {
             }
         }
         if (parameters != null) {
-            for (Parameter param : parameters) {
-                Object value = param.getValue();
-                if (null != value && value instanceof Number) {
-                    count++;
-                    next((Number)value);
-                }
+            for (Number value : Parameter.toList(Number.class, ctx, parameters)) {
+                count++;
+                next(value);
             }
         }
         if (count != 0) {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
@@ -11,7 +11,6 @@ import java.util.List;
  * String function concat - simple takes a list of arguments and/or an array and concatenates them together to form a
  * single string
  *
- * Created by mgreenwood on 12/11/15.
  */
 public class Concatenate implements PathFunction {
     @Override
@@ -26,11 +25,8 @@ public class Concatenate implements PathFunction {
             }
         }
         if (parameters != null) {
-            for (Parameter param : parameters) {
-		Object value = param.getValue();
-                if (value != null) {
-                    result.append(value.toString());
-                }
+            for (String value : Parameter.toList(String.class, ctx, parameters)) {
+                result.append(value);
             }
         }
         return result.toString();

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/CompiledPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/CompiledPath.java
@@ -19,8 +19,12 @@ import com.jayway.jsonpath.internal.EvaluationAbortException;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.PathRef;
+import com.jayway.jsonpath.internal.function.ParamType;
+import com.jayway.jsonpath.internal.function.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
 
 public class CompiledPath implements Path {
 
@@ -32,13 +36,55 @@ public class CompiledPath implements Path {
 
 
     public CompiledPath(RootPathToken root, boolean isRootPath) {
-        this.root = root;
+        this.root = invertScannerFunctionRelationship(root);
         this.isRootPath = isRootPath;
     }
 
     @Override
     public boolean isRootPath() {
         return isRootPath;
+    }
+
+
+
+    /**
+     * In the event the writer of the path referenced a function at the tail end of a scanner, augment the query such
+     * that the root node is the function and the parameter to the function is the scanner.   This way we maintain
+     * relative sanity in the path expression, functions either evaluate scalar values or arrays, they're
+     * not re-entrant nor should they maintain state, they do however take parameters.
+     *
+     * @param path
+     *      this is our old root path which will become a parameter (assuming there's a scanner terminated by a function
+     *
+     * @return
+     *      A function with the scanner as input, or if this situation doesn't exist just the input path
+     */
+    private RootPathToken invertScannerFunctionRelationship(final RootPathToken path) {
+        if (path.isFunctionPath() && path.next() instanceof ScanPathToken) {
+            PathToken token = path;
+            PathToken prior = null;
+            while (null != (token = token.next()) && !(token instanceof FunctionPathToken)) {
+                prior = token;
+            }
+            // Invert the relationship $..path.function() to $.function($..path)
+            if (token instanceof FunctionPathToken) {
+                prior.setNext(null);
+                path.setTail(prior);
+
+                // Now generate a new parameter from our path
+                Parameter parameter = new Parameter();
+                parameter.setPath(new CompiledPath(path, true));
+                parameter.setType(ParamType.PATH);
+                ((FunctionPathToken)token).setParameters(Arrays.asList(parameter));
+                RootPathToken functionRoot = new RootPathToken('$');
+                functionRoot.setTail(token);
+                functionRoot.setNext(token);
+
+                // Define the function as the root
+                return functionRoot;
+            }
+        }
+        return path;
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -20,7 +20,7 @@ public class FunctionPathToken extends PathToken {
 
     private final String functionName;
     private final String pathFragment;
-    private final List<Parameter> functionParams;
+    private List<Parameter> functionParams;
 
     public FunctionPathToken(String pathFragment, List<Parameter> parameters) {
         this.pathFragment = pathFragment + ((parameters != null && parameters.size() > 0) ? "(...)" : "()");
@@ -81,4 +81,7 @@ public class FunctionPathToken extends PathToken {
     }
 
 
+    public void setParameters(List<Parameter> parameters) {
+        this.functionParams = parameters;
+    }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
@@ -215,4 +215,7 @@ public abstract class PathToken {
 
     protected abstract String getPathFragment();
 
+    public void setNext(final PathToken next) {
+        this.next = next;
+    }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/RootPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/RootPathToken.java
@@ -76,4 +76,8 @@ public class RootPathToken extends PathToken {
     public boolean isFunctionPath() {
         return (tail instanceof FunctionPathToken);
     }
+
+    public void setTail(PathToken token) {
+        this.tail = token;
+    }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
@@ -1,0 +1,43 @@
+package com.jayway.jsonpath.internal.function;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Configurations;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * TDD for Issue 191
+ *
+ * Shows aggregation across fields rather than within a single entity.
+ *
+ */
+public class Issue191 extends com.jayway.jsonpath.internal.function.BaseFunctionTest {
+
+    private Configuration conf = Configurations.GSON_CONFIGURATION;
+
+    @Test
+    public void testResultSetNumericComputation() {
+        InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
+        Long value = JsonPath.parse(stream).read("$.max($..timestamp)", Long.class);
+        assertEquals("Expected the max function to consume the aggregation parameters and calculate the max over the result set",
+                Long.valueOf(1427310341), value);
+    }
+
+    @Test
+    public void testConcatResultSet() {
+        InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
+        String concatResult = JsonPath.parse(stream).read("$.concat($..state)", String.class);
+        assertEquals("Expected a string length to be a concat of all of the states", concatResult.length(), 806);
+    }
+
+    @Test
+    public void testConcatWithNumericValueAsString() {
+        InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
+        String concatResult = JsonPath.parse(stream).read("$.concat($..cpus)", String.class);
+        assertEquals("Expected a string length to be a concat of all of the cpus", concatResult.length(), 489);
+    }
+}

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
@@ -36,6 +36,14 @@ public class Issue191 {
     }
 
     @Test
+    public void testResultSetNumericComputationRecursiveReplacement() {
+        InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
+        Long value = JsonPath.parse(stream).read("$.max($..timestamp.avg(), $..timestamp.stddev())", Long.class);
+        assertEquals("Expected the max function to consume the aggregation parameters and calculate the max over the result set",
+                Long.valueOf(1427188672L), value);
+    }
+
+    @Test
     public void testMultipleResultSetSums() {
         InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
         Long value = JsonPath.parse(stream).read("$.sum($..timestamp, $..cpus)", Long.class);

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
@@ -28,6 +28,14 @@ public class Issue191 {
     }
 
     @Test
+    public void testResultSetNumericComputationTail() {
+        InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
+        Long value = JsonPath.parse(stream).read("$..timestamp.sum()", Long.class);
+        assertEquals("Expected the max function to consume the aggregation parameters and calculate the max over the result set",
+                Long.valueOf(35679716813L), value);
+    }
+
+    @Test
     public void testMultipleResultSetSums() {
         InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
         Long value = JsonPath.parse(stream).read("$.sum($..timestamp, $..cpus)", Long.class);

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue191.java
@@ -15,16 +15,24 @@ import static org.junit.Assert.assertEquals;
  * Shows aggregation across fields rather than within a single entity.
  *
  */
-public class Issue191 extends com.jayway.jsonpath.internal.function.BaseFunctionTest {
+public class Issue191 {
 
     private Configuration conf = Configurations.GSON_CONFIGURATION;
 
     @Test
     public void testResultSetNumericComputation() {
         InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
-        Long value = JsonPath.parse(stream).read("$.max($..timestamp)", Long.class);
+        Long value = JsonPath.parse(stream).read("$.sum($..timestamp)", Long.class);
         assertEquals("Expected the max function to consume the aggregation parameters and calculate the max over the result set",
-                Long.valueOf(1427310341), value);
+                Long.valueOf(35679716813L), value);
+    }
+
+    @Test
+    public void testMultipleResultSetSums() {
+        InputStream stream = ClassLoader.getSystemResourceAsStream("issue_191.json");
+        Long value = JsonPath.parse(stream).read("$.sum($..timestamp, $..cpus)", Long.class);
+        assertEquals("Expected the max function to consume the aggregation parameters and calculate the max over the result set",
+                Long.valueOf(35679716835L), value);
     }
 
     @Test

--- a/json-path/src/test/resources/issue_191.json
+++ b/json-path/src/test/resources/issue_191.json
@@ -1,0 +1,1258 @@
+{
+    "activated_slaves": 5,
+    "build_date": "2015-01-09 02:25:21",
+    "build_time": 1420770321,
+    "build_user": "root",
+    "completed_frameworks": [
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172738-2049997834-5050-23289-0433",
+                    "id": "mesos-jenkins-172c6f74-12bc-44fe-849a-ad902ddc2b64",
+                    "name": "task mesos-jenkins-172c6f74-12bc-44fe-849a-ad902ddc2b64",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427206149.38254
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427207981.47819
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 0,
+            "hostname": "ip-10-124-48-147.ec2.internal",
+            "id": "20150225-172738-2049997834-5050-23289-0433",
+            "name": "Jenkins Scheduler",
+            "offered_resources": {
+                "cpus": -2.22044604925031e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427207787.01579,
+            "reregistered_time": 1427207787.0158,
+            "resources": {
+                "cpus": -2.22044604925031e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 1427207981.47898,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "jenkins",
+            "webui_url": ""
+        },
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172748-1513192458-5050-6647-0000",
+                    "id": "mesos-jenkins-cd18b433-e2ee-4a4e-875b-6ea82d90a53a",
+                    "name": "task mesos-jenkins-cd18b433-e2ee-4a4e-875b-6ea82d90a53a",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172748-1513192458-5050-6647-S0",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427209005.01389
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427209961.51519
+                        }
+                    ]
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172748-1513192458-5050-6647-0000",
+                    "id": "mesos-jenkins-66fca7c0-88f7-4a1a-9796-a6de2e337b0a",
+                    "name": "task mesos-jenkins-66fca7c0-88f7-4a1a-9796-a6de2e337b0a",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S25",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427209025.84128
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427211101.4792
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 0,
+            "hostname": "ip-10-124-48-147.ec2.internal",
+            "id": "20150225-172748-1513192458-5050-6647-0000",
+            "name": "Jenkins Scheduler",
+            "offered_resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427208985.06716,
+            "resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 1427211101.48013,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "jenkins",
+            "webui_url": ""
+        },
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172748-1513192458-5050-6647-0001",
+                    "id": "mesos-jenkins-258ad47c-85bf-4fe0-b7c4-4f0cc70f2998",
+                    "name": "task mesos-jenkins-258ad47c-85bf-4fe0-b7c4-4f0cc70f2998",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427211139.85003
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427212121.47896
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 0,
+            "hostname": "ip-10-124-48-147.ec2.internal",
+            "id": "20150225-172748-1513192458-5050-6647-0001",
+            "name": "Jenkins Scheduler",
+            "offered_resources": {
+                "cpus": 2.22044604925031e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427211125.06385,
+            "resources": {
+                "cpus": 2.22044604925031e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 1427212121.4797,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "jenkins",
+            "webui_url": ""
+        },
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172748-1513192458-5050-6647-0002",
+                    "id": "mesos-jenkins-f30e5e34-2ef6-4993-9260-73ee3520c0a5",
+                    "name": "task mesos-jenkins-f30e5e34-2ef6-4993-9260-73ee3520c0a5",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427213316.78467
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427214401.47958
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 0,
+            "hostname": "ip-10-124-48-147.ec2.internal",
+            "id": "20150225-172748-1513192458-5050-6647-0002",
+            "name": "Jenkins Scheduler",
+            "offered_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427213305.0687,
+            "resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 1427214401.48033,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "jenkins",
+            "webui_url": ""
+        },
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172748-1513192458-5050-6647-0003",
+                    "id": "mesos-jenkins-1fc0bbd8-f0ff-48cd-a7f7-24a9436ba6bc",
+                    "name": "task mesos-jenkins-1fc0bbd8-f0ff-48cd-a7f7-24a9436ba6bc",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427215879.15661
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427217701.47961
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 0,
+            "hostname": "ip-10-124-48-147.ec2.internal",
+            "id": "20150225-172748-1513192458-5050-6647-0003",
+            "name": "Jenkins Scheduler",
+            "offered_resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427215868.06173,
+            "resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 1427217701.48035,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "jenkins",
+            "webui_url": ""
+        },
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172748-1513192458-5050-6647-0004",
+                    "id": "mesos-jenkins-62b44026-843d-4813-a6a8-e95215250bb1",
+                    "name": "task mesos-jenkins-62b44026-843d-4813-a6a8-e95215250bb1",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427222969.79605
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427223941.48583
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 0,
+            "hostname": "ip-10-124-48-147.ec2.internal",
+            "id": "20150225-172748-1513192458-5050-6647-0004",
+            "name": "Jenkins Scheduler",
+            "offered_resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427222958.07464,
+            "resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 1427223941.48665,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "jenkins",
+            "webui_url": ""
+        },
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150225-172748-1513192458-5050-6647-0005",
+                    "id": "mesos-jenkins-807b9b8a-3283-4e78-94e1-9dc17df4df77",
+                    "name": "task mesos-jenkins-807b9b8a-3283-4e78-94e1-9dc17df4df77",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 704
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S25",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427309356.80847
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427310341.47914
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 0,
+            "hostname": "ip-10-124-48-147.ec2.internal",
+            "id": "20150225-172748-1513192458-5050-6647-0005",
+            "name": "Jenkins Scheduler",
+            "offered_resources": {
+                "cpus": -2.22044604925031e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427309345.18029,
+            "resources": {
+                "cpus": -2.22044604925031e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 1427310341.47995,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "jenkins",
+            "webui_url": ""
+        }
+    ],
+    "deactivated_slaves": 0,
+    "elected_time": 1427207786.0144,
+    "failed_tasks": 0,
+    "finished_tasks": 0,
+    "flags": {
+        "allocation_interval": "1secs",
+        "authenticate": "false",
+        "authenticate_slaves": "false",
+        "authenticators": "crammd5",
+        "framework_sorter": "drf",
+        "help": "false",
+        "hostname": "10.124.49.90",
+        "initialize_driver_logging": "true",
+        "log_auto_initialize": "true",
+        "log_dir": "/var/log/mesos",
+        "logbufsecs": "0",
+        "logging_level": "INFO",
+        "port": "5050",
+        "quiet": "false",
+        "quorum": "2",
+        "recovery_slave_removal_limit": "100%",
+        "registry": "replicated_log",
+        "registry_fetch_timeout": "1mins",
+        "registry_store_timeout": "5secs",
+        "registry_strict": "false",
+        "root_submissions": "true",
+        "slave_reregister_timeout": "10mins",
+        "user_sorter": "drf",
+        "version": "false",
+        "webui_dir": "/usr/share/mesos/webui",
+        "whitelist": "*",
+        "work_dir": "/var/lib/mesos",
+        "zk": "zk://10.124.48.221:2181,10.124.49.12:2181,10.124.50.67:2181/mesos",
+        "zk_session_timeout": "10secs"
+    },
+    "frameworks": [
+        {
+            "active": true,
+            "checkpoint": false,
+            "completed_tasks": [],
+            "failover_timeout": 1200,
+            "hostname": "ip-10-124-50-210.us-east-1.aws.cloud.in.here.com",
+            "id": "20150203-224144-2049997834-5050-8713-0000",
+            "name": "chronos-2.2.0_mesos-0.20.0-SNAPSHOT",
+            "offered_resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427207787.01469,
+            "reregistered_time": 1427207787.0147,
+            "resources": {
+                "cpus": -8.88178419700125e-16,
+                "disk": 0,
+                "mem": 0
+            },
+            "role": "*",
+            "tasks": [],
+            "unregistered_time": 0,
+            "used_resources": {
+                "cpus": 0,
+                "disk": 0,
+                "mem": 0
+            },
+            "user": "root",
+            "webui_url": ""
+        },
+        {
+            "active": true,
+            "checkpoint": true,
+            "completed_tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.95f49d05-c9bf-11e4-a1fc-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31000-31000]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_KILLED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.a40abda6-ca02-11e4-a1fc-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31000-31000]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_KILLED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.3946a287-ca67-11e4-a1fc-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31000-31000]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_KILLED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.fec0c74c-ce11-11e4-a1fc-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31000-31000]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_KILLED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.33d4007e-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31561-31561]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.359deb0f-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31939-31939]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.50773d6a-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31908-31908]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.638fd9ce-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31658-31658]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.81fd2852-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31160-31160]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.afedb77b-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31185-31185]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.0243c011-cf38-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31554-31554]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.4bdb1099-d1de-11e4-a1fc-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31000-31000]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S19",
+                    "state": "TASK_KILLED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "sdp_shared_jenkins-master.eb8f2863-c9a2-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.shared.sdp",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31458-31458]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.c7865efb-cd05-11e4-a1fc-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31000-31000]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_KILLED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.37684ad0-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31223-31223]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.3c2e3752-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31703-31703]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.405b3f34-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31996-31996]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.44886e26-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31141-31141]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.54a4936b-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31109-31109]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.58d1e96c-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31110-31110]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.5d97fcfd-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31167-31167]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.6986f34f-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31158-31158]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.790a33f1-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31696-31696]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.8c2149b3-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31258-31258]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.9c3d47e4-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31308-31308]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.a06a01a6-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31252-31252]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.fa821fbd-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31111-31111]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.fbb39ade-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31658-31658]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.ffe0f0e0-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31022-31022]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.04a68f42-cf38-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31583-31583]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.4ce2cc09-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31449-31449]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S25",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.a792e469-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31299-31299]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S25",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.fe166a0f-cf37-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31383-31383]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S25",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_jenkins-master.0670c7f3-cf38-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.test",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31607-31607]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S25",
+                    "state": "TASK_FAILED",
+                    "statuses": []
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dev_frontend.3950b432-d234-11e4-bc5e-56847afe9799",
+                    "name": "frontend.dev.test",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 1024,
+                        "ports": "[31980-31980, 31000-31002]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S21",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427208248.01184
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427208510.81702
+                        }
+                    ]
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.c3a7d253-d241-11e4-bc5e-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31584-31584]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S21",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427214063.25571
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427214249.31952
+                        }
+                    ]
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dv_helloworld.d7c6b3c4-d244-11e4-bc5e-56847afe9799",
+                    "name": "helloworld.dv.test",
+                    "resources": {
+                        "cpus": 0.1,
+                        "disk": 0,
+                        "mem": 32,
+                        "ports": "[31000-31000]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S27",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427215390.066
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427215571.78983
+                        }
+                    ]
+                },
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "test_dev_frontend.a0f3f185-d2e6-11e4-bc5e-56847afe9799",
+                    "name": "frontend.dev.test",
+                    "resources": {
+                        "cpus": 0.2,
+                        "disk": 0,
+                        "mem": 1024,
+                        "ports": "[31980-31980, 31000-31002]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S25",
+                    "state": "TASK_KILLED",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1427285021.3087
+                        },
+                        {
+                            "state": "TASK_KILLED",
+                            "timestamp": 1427285124.9842
+                        }
+                    ]
+                }
+            ],
+            "failover_timeout": 604800,
+            "hostname": "ip-10-124-49-90.ec2.internal",
+            "id": "20150127-110351-1513192458-5050-8587-0000",
+            "name": "marathon",
+            "offered_resources": {
+                "cpus": -2.44249065417534e-15,
+                "disk": 0,
+                "mem": 0
+            },
+            "offers": [],
+            "registered_time": 1427207786.075,
+            "reregistered_time": 1427289460.06666,
+            "resources": {
+                "cpus": 0.299999999999998,
+                "disk": 0,
+                "mem": 768,
+                "ports": "[31583-31583]"
+            },
+            "role": "*",
+            "tasks": [
+                {
+                    "executor_id": "",
+                    "framework_id": "20150127-110351-1513192458-5050-8587-0000",
+                    "id": "sdp_shared_jenkins-master.ed596114-c9a2-11e4-a1fc-56847afe9799",
+                    "name": "jenkins-master.shared.sdp",
+                    "resources": {
+                        "cpus": 0.3,
+                        "disk": 0,
+                        "mem": 768,
+                        "ports": "[31583-31583]"
+                    },
+                    "slave_id": "20150225-172738-2049997834-5050-23289-S21",
+                    "state": "TASK_RUNNING",
+                    "statuses": [
+                        {
+                            "state": "TASK_RUNNING",
+                            "timestamp": 1426266239.30745
+                        }
+                    ]
+                }
+            ],
+            "unregistered_time": 0,
+            "used_resources": {
+                "cpus": 0.3,
+                "disk": 0,
+                "mem": 768,
+                "ports": "[31583-31583]"
+            },
+            "user": "root",
+            "webui_url": ""
+        }
+    ],
+    "git_sha": "2ae1ba91e64f92ec71d327e10e6ba9e8ad5477e8",
+    "git_tag": "0.21.1",
+    "hostname": "10.124.49.90",
+    "id": "20150225-172748-1513192458-5050-6647",
+    "killed_tasks": 12,
+    "leader": "master@10.124.49.90:5050",
+    "log_dir": "/var/log/mesos",
+    "lost_tasks": 0,
+    "orphan_tasks": [],
+    "pid": "master@10.124.49.90:5050",
+    "slaves": [
+        {
+            "attributes": {
+                "az": "us-east-1b",
+                "instance_id": "i-496a92b3",
+                "instance_type": "c3.large"
+            },
+            "hostname": "10.124.49.190",
+            "id": "20150225-172748-1513192458-5050-6647-S0",
+            "pid": "slave(1)@10.124.49.190:5051",
+            "registered_time": 1427207786.83581,
+            "resources": {
+                "cpus": 2,
+                "disk": 3966,
+                "mem": 2744,
+                "ports": "[31000-32000]"
+            }
+        },
+        {
+            "attributes": {
+                "az": "us-east-1c",
+                "instance_id": "i-b57fe25a",
+                "instance_type": "c3.large"
+            },
+            "hostname": "10.124.50.153",
+            "id": "20150225-172738-2049997834-5050-23289-S27",
+            "pid": "slave(1)@10.124.50.153:5051",
+            "registered_time": 1427207786.63308,
+            "reregistered_time": 1427207786.63309,
+            "resources": {
+                "cpus": 2,
+                "disk": 3966,
+                "mem": 2744,
+                "ports": "[31000-32000]"
+            }
+        },
+        {
+            "attributes": {
+                "az": "us-east-1c",
+                "instance_id": "i-2467dccb",
+                "instance_type": "c3.large"
+            },
+            "hostname": "10.124.50.12",
+            "id": "20150225-172748-1513192458-5050-6647-S2",
+            "pid": "slave(1)@10.124.50.12:5051",
+            "registered_time": 1427399742.96888,
+            "resources": {
+                "cpus": 2,
+                "disk": 3966,
+                "mem": 2744,
+                "ports": "[31000-32000]"
+            }
+        },
+        {
+            "attributes": {
+                "az": "us-east-1a",
+                "instance_id": "i-b33a5842",
+                "instance_type": "c3.large"
+            },
+            "hostname": "10.124.48.198",
+            "id": "20150225-172738-2049997834-5050-23289-S25",
+            "pid": "slave(1)@10.124.48.198:5051",
+            "registered_time": 1427207786.94212,
+            "reregistered_time": 1427207786.94213,
+            "resources": {
+                "cpus": 2,
+                "disk": 3966,
+                "mem": 2744,
+                "ports": "[31000-32000]"
+            }
+        },
+        {
+            "attributes": {
+                "az": "us-east-1a",
+                "instance_id": "i-9bdcde6a",
+                "instance_type": "c3.large"
+            },
+            "hostname": "10.124.48.147",
+            "id": "20150225-172738-2049997834-5050-23289-S21",
+            "pid": "slave(1)@10.124.48.147:5051",
+            "registered_time": 1427207786.33104,
+            "reregistered_time": 1427207786.33115,
+            "resources": {
+                "cpus": 2,
+                "disk": 3966,
+                "mem": 2744,
+                "ports": "[31000-32000]"
+            }
+        }
+    ],
+    "staged_tasks": 11,
+    "start_time": 1424885268.34093,
+    "started_tasks": 0,
+    "unregistered_frameworks": [
+        "20150225-172738-2049997834-5050-23289-0433",
+        "20150225-172738-2049997834-5050-23289-0433",
+        "20150225-172738-2049997834-5050-23289-0433",
+        "20150225-172738-2049997834-5050-23289-0433"
+    ],
+    "version": "0.21.1"
+}


### PR DESCRIPTION
Issue #191 is an unintentional side-effect of the collection processing for parameters passed to functions.  This change supports result set functions via patterns such as:

$.max($..allTheNumberThings)
    
$.max($.foo, $.bar) is already supported where foo and bar are numbers - consequently 

$.max($..allTheNumberThings) shall also work also 

$.avg($..allTheNumberThings, $.someCollection.max(), $..someOtherNumberThings)
will work too now with this change.