### PR TITLE
Recent changes to providers broke ValueNode.asValueListNode

### DIFF
--- a/json-path/src/test/java/com/jayway/jsonpath/internal/filter/ValueNodeTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/filter/ValueNodeTest.java
@@ -1,0 +1,61 @@
+package com.jayway.jsonpath.internal.filter;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Configuration.Defaults;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ValueNodeTest {
+
+   private static class TestDefaults implements Defaults {
+
+      TestDefaults() {}
+
+      @Override
+      public JsonProvider jsonProvider() {
+         return new JacksonJsonNodeJsonProvider();
+      }
+
+      @Override
+      public MappingProvider mappingProvider() {
+         return new JacksonMappingProvider();
+      }
+
+      @Override
+      public Set<Option> options() {
+         return EnumSet.noneOf(Option.class);
+      }
+   }
+
+   private static final String JSON = "{\n" +
+         "    \"nodes\": {\n" +
+         "        \"unnamed1\": {\n" +
+         "            \"ntpServers\": [\n" +
+         "                \"1.2.3.4\"\n" +
+         "            ]\n" +
+         "        }\n" +
+         "    }\n" +
+         "}";
+
+   @Test
+   public void testOneNtpServer() throws Exception {
+      Configuration.setDefaults(new TestDefaults());
+      DocumentContext ctx = JsonPath.using(Configuration.defaultConfiguration()).parse(JSON);
+
+      String path = "$.nodes[*][?(!([\"1.2.3.4\"] subsetof @.ntpServers))].ntpServers";
+      JsonPath jsonPath = JsonPath.compile(path);
+
+      ctx.read(jsonPath);
+   }
+}


### PR DESCRIPTION
See the test in this PR. The stack trace is below.

Some points of data:

* The broken code seems to have been introduced in https://github.com/json-path/JsonPath/pull/314

* The issue here seems to be a mismatch when `parsed = true`: then [`parse(ctx)`](https://github.com/json-path/JsonPath/blame/master/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java#L345) will use the already-parsed version. However, the only way that `parsed = true` is actually when the pre-parsed object has been passed into this [class via constructor](https://github.com/json-path/JsonPath/blame/master/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java#L314); and it will necessarily have gone through the [user's provider](https://github.com/json-path/JsonPath/blame/master/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java#L840), not JsonSmart, in this case.

Any advice is appreciated -- we have a hack around the issue but I'm not very confident in it.

(We simply revert the code that uses JsonSmart, after configuring the Jackson[Node]JsonProvider to allow single quotes.)


```
java.lang.ClassCastException: com.fasterxml.jackson.databind.node.ArrayNode cannot be cast to java.util.List

	at com.jayway.jsonpath.internal.filter.ValueNode.asValueListNode(ValueNode.java:341)
	at com.jayway.jsonpath.internal.filter.EvaluatorFactory.evaluate(EvaluatorFactory.java:274)
	at com.jayway.jsonpath.internal.filter.RelationalExpressionNode.apply(RelationalExpressionNode.java:44)
	at com.jayway.jsonpath.internal.filter.LogicalExpressionNode.apply(LogicalExpressionNode.java:84)
	at com.jayway.jsonpath.internal.filter.FilterCompiler.apply(FilterCompiler.java:415)
	at com.jayway.jsonpath.internal.path.PredicatePathToken.accept(PredicatePathToken.java:76)
	at com.jayway.jsonpath.internal.path.PredicatePathToken.evaluate(PredicatePathToken.java:46)
	at com.jayway.jsonpath.internal.path.PathToken.handleObjectProperty(PathToken.java:81)
	at com.jayway.jsonpath.internal.path.WildcardPathToken.evaluate(WildcardPathToken.java:35)
	at com.jayway.jsonpath.internal.path.PathToken.handleObjectProperty(PathToken.java:81)
	at com.jayway.jsonpath.internal.path.PropertyPathToken.evaluate(PropertyPathToken.java:79)
	at com.jayway.jsonpath.internal.path.RootPathToken.evaluate(RootPathToken.java:62)
	at com.jayway.jsonpath.internal.path.CompiledPath.evaluate(CompiledPath.java:53)
	at com.jayway.jsonpath.internal.path.CompiledPath.evaluate(CompiledPath.java:61)
	at com.jayway.jsonpath.JsonPath.read(JsonPath.java:187)
	at com.jayway.jsonpath.internal.JsonContext.read(JsonContext.java:102)
	at com.jayway.jsonpath.internal.filter.ValueNodeTest.testOneNtpServer(ValueNodeTest.java:77)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access-zsh(ParentRunner.java:58)
	at org.junit.runners.ParentRunner.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
java.lang.ClassCastException: com.fasterxml.jackson.databind.node.ArrayNode cannot be cast to java.util.List

	at com.jayway.jsonpath.internal.filter.ValueNode.asValueListNode(ValueNode.java:341)
	at com.jayway.jsonpath.internal.filter.EvaluatorFactory.evaluate(EvaluatorFactory.java:274)
	at com.jayway.jsonpath.internal.filter.RelationalExpressionNode.apply(RelationalExpressionNode.java:44)
	at com.jayway.jsonpath.internal.filter.LogicalExpressionNode.apply(LogicalExpressionNode.java:84)
	at com.jayway.jsonpath.internal.filter.FilterCompiler.apply(FilterCompiler.java:415)
	at com.jayway.jsonpath.internal.path.PredicatePathToken.accept(PredicatePathToken.java:76)
	at com.jayway.jsonpath.internal.path.PredicatePathToken.evaluate(PredicatePathToken.java:46)
	at com.jayway.jsonpath.internal.path.PathToken.handleObjectProperty(PathToken.java:81)
	at com.jayway.jsonpath.internal.path.WildcardPathToken.evaluate(WildcardPathToken.java:35)
	at com.jayway.jsonpath.internal.path.PathToken.handleObjectProperty(PathToken.java:81)
	at com.jayway.jsonpath.internal.path.PropertyPathToken.evaluate(PropertyPathToken.java:79)
	at com.jayway.jsonpath.internal.path.RootPathToken.evaluate(RootPathToken.java:62)
	at com.jayway.jsonpath.internal.path.CompiledPath.evaluate(CompiledPath.java:53)
	at com.jayway.jsonpath.internal.path.CompiledPath.evaluate(CompiledPath.java:61)
	at com.jayway.jsonpath.JsonPath.read(JsonPath.java:187)
	at com.jayway.jsonpath.internal.JsonContext.read(JsonContext.java:102)
	at com.jayway.jsonpath.internal.filter.ValueNodeTest.testOneNtpServer(ValueNodeTest.java:77)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access-zsh(ParentRunner.java:58)
	at org.junit.runners.ParentRunner.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```