### PR TITLE
Prevent StackOverflow in case of unclosed property

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -603,6 +603,10 @@ public class PathCompiler {
             readPosition++;
         }
 
+        if (inProperty){
+            fail("Property has not been closed - missing closing " + potentialStringDelimiter);
+        }
+
         int endBracketIndex = path.indexOfNextSignificantChar(endPosition, CLOSE_SQUARE_BRACKET) + 1;
 
         path.setPosition(endBracketIndex);

--- a/json-path/src/test/java/com/jayway/jsonpath/old/JsonPathTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/JsonPathTest.java
@@ -322,5 +322,10 @@ public class JsonPathTest extends BaseTest {
         }
     }
 
+    @Test(expected = InvalidPathException.class)
+    //see https://github.com/json-path/JsonPath/issues/428
+    public void prevent_stack_overflow_error_when_unclosed_property() {
+        JsonPath.compile("$['boo','foo][?(@ =~ /bar/)]");
+    }
 
 }


### PR DESCRIPTION
Hi contributors !

from my understanding, problem is that there is not "end condition" for unclosed property inside `readBracketPropertyToken` and because of that `endPosition` is never updated.
From my analysis (I can be wrong of course), it is sufficient to check that we we left the property, because this is always true for properly formatted JSON path expression. 

happy to get feedback !