### PR TITLE
Log the nested exception as well

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
@@ -93,7 +93,7 @@ public class JacksonJsonProvider extends AbstractJsonProvider {
             generator.close();
             return writer.getBuffer().toString();
         } catch (IOException e) {
-            throw new InvalidJsonException();
+            throw new InvalidJsonException(e);
         }
     }
 


### PR DESCRIPTION
I used jackson for logging on a debug level. Example:
`logger.debug("With body: " + jsonPath.parse(body).jsonString());`
Only by debugging I was able to actually find out what was the problem. I wouldn't have to debug if the exception was nested here.