### PR TITLE
Fixes #447: To report correct index of invalid jsonpath failure. This…

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -484,7 +484,8 @@ public class PathCompiler {
         if (inBracket) {
             int wildCardIndex = path.indexOfNextSignificantChar(WILDCARD);
             if (!path.nextSignificantCharIs(wildCardIndex, CLOSE_SQUARE_BRACKET)) {
-                throw new InvalidPathException("Expected wildcard token to end with ']' on position " + wildCardIndex + 1);
+                int offset = wildCardIndex + 1;
+                throw new InvalidPathException("Expected wildcard token to end with ']' on position " + offset);
             }
             int bracketCloseIndex = path.indexOfNextSignificantChar(wildCardIndex, CLOSE_SQUARE_BRACKET);
             path.setPosition(bracketCloseIndex + 1);


### PR DESCRIPTION
… should add 1 to the position instead of appending 1 to its text value.

Signed-off-by: Claus Ibsen <claus.ibsen@gmail.com>