### PR TITLE
Allow the cache and functions to be configurable in different contexts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ TODO
 gradle.properties
 build
 bin/
+json-path-assert/out
+json-path-web-test/out
+json-path/out

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -215,7 +215,7 @@ public class JsonContext implements DocumentContext {
     }
 
     private JsonPath pathFromCache(String path, Predicate[] filters) {
-        Cache cache = CacheProvider.getCache();
+        Cache cache = configuration.getCache() != null ? configuration.getCache() : CacheProvider.getCache();
         String cacheKey = Utils.concat(path, new LinkedList<Predicate>(asList(filters)).toString());
         JsonPath jsonPath = cache.get(cacheKey);
         if (jsonPath == null) {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -35,7 +35,7 @@ public class FunctionPathToken extends PathToken {
 
     @Override
     public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
-        PathFunction pathFunction = PathFunctionFactory.newFunction(functionName);
+        PathFunction pathFunction = PathFunctionFactory.newFunction(functionName, ctx.configuration());
         evaluateParameters(currentPath, parent, model, ctx);
         Object result = pathFunction.invoke(currentPath, parent, model, ctx, functionParams);
         ctx.addResult(currentPath + "." + functionName, parent, result);

--- a/json-path/src/test/java/com/jayway/jsonpath/ConfigurableFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/ConfigurableFunctionTest.java
@@ -1,0 +1,50 @@
+package com.jayway.jsonpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+import com.jayway.jsonpath.internal.EvaluationContext;
+import com.jayway.jsonpath.internal.PathRef;
+import com.jayway.jsonpath.internal.function.Parameter;
+import com.jayway.jsonpath.internal.function.PathFunction;
+import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
+import java.util.List;
+import org.junit.Test;
+
+public class ConfigurableFunctionTest {
+  private static String CONSTANT = "A constant value";
+  public static class MyFunction implements PathFunction {
+
+    @Override
+    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx,
+        List<Parameter> parameters) {
+      return CONSTANT;
+    }
+  }
+
+  @Test
+  public void testConfigurableCustomFunction() {
+    Configuration withoutFunction = Configuration
+        .builder()
+        .mappingProvider(new JsonOrgMappingProvider())
+        .jsonProvider(new JsonOrgJsonProvider())
+        .build();
+
+    Configuration withFunction = Configuration
+        .builder()
+        .mappingProvider(new JsonOrgMappingProvider())
+        .addFunction("constant", MyFunction.class)
+        .jsonProvider(new JsonOrgJsonProvider())
+        .build();
+    assertThat(JsonPath.using(withFunction).parse("{}")
+        .read("$.constant()")).isEqualTo(CONSTANT);
+    try {
+      JsonPath.using(withoutFunction).parse("{}")
+          .read("$.constant()");
+      failBecauseExceptionWasNotThrown(InvalidPathException.class);
+    } catch (InvalidPathException e) {
+      assertThat(e.getMessage()).isEqualTo("Function with name: constant does not exist.");
+    }
+  }
+}


### PR DESCRIPTION
Allow the cache to be configurable in different contexts, and as well as which Functions are available on the library, currently is not possible to use different cache policies in the same JVM context since CacheProvider is statically set, same with Functions