### PR TITLE
Fix compiling of functions with single character arguments

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -195,7 +195,7 @@ public class PathCompiler {
             }
             else if (c == OPEN_PARENTHESIS) {
                 isFunction = true;
-                endPosition = readPosition++;
+                endPosition = readPosition;
                 break;
             }
             readPosition++;

--- a/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
@@ -252,6 +252,14 @@ public class PathCompilerTest {
         assertThat(result).containsExactly("] it");
     }
 
+    @Test
+    public void a_function_can_be_compiled() {
+        assertThat(compile("$.aaa.foo()").toString()).isEqualTo("$['aaa'].foo()");
+        assertThat(compile("$.aaa.foo(5)").toString()).isEqualTo("$['aaa'].foo(...)");
+        assertThat(compile("$.aaa.foo($.bar)").toString()).isEqualTo("$['aaa'].foo(...)");
+        assertThat(compile("$.aaa.foo(5,10,15)").toString()).isEqualTo("$['aaa'].foo(...)");
+    }
+
     @Test(expected = InvalidPathException.class)
     public void array_indexes_must_be_separated_by_commas() {
         compile("$[0, 1, 2 4]");

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
@@ -59,6 +59,12 @@ public class NestedFunctionTest extends BaseFunctionTest {
     }
 
     @Test
+    public void testSimpleLiteralArgument() {
+        verifyMathFunction(conf, "$.sum(5)", 5.0);
+        verifyMathFunction(conf, "$.sum(50)", 50.0);
+    }
+
+    @Test
     public void testStringConcat() {
         verifyTextFunction(conf, "$.text.concat()", "abcdef");
     }


### PR DESCRIPTION
As written, PathCompiler actually skips the first character in the argument field of a function. This causes single character arguments to be compiled as no-arg functions.