### PR TITLE
Added ability for predicates to filter by the name of a node.

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -18,12 +18,7 @@ import com.jayway.jsonpath.internal.DefaultsImpl;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
+import java.util.*;
 
 import static com.jayway.jsonpath.internal.Utils.notNull;
 import static java.util.Arrays.asList;

--- a/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Criteria.java
@@ -19,18 +19,14 @@ import com.jayway.jsonpath.internal.Utils;
 import com.jayway.jsonpath.internal.filter.RelationalExpressionNode;
 import com.jayway.jsonpath.internal.filter.RelationalOperator;
 import com.jayway.jsonpath.internal.filter.ValueNode;
+import com.jayway.jsonpath.internal.filter.ValueNodes;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static com.jayway.jsonpath.internal.Utils.notNull;
-import com.jayway.jsonpath.internal.filter.ValueNodes;
-import static com.jayway.jsonpath.internal.filter.ValueNodes.ValueListNode;
 import static com.jayway.jsonpath.internal.filter.ValueNodes.PredicateNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.ValueListNode;
 
 /**
  *

--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -15,11 +15,7 @@
 package com.jayway.jsonpath;
 
 
-import com.jayway.jsonpath.internal.EvaluationContext;
-import com.jayway.jsonpath.internal.ParseContextImpl;
-import com.jayway.jsonpath.internal.Path;
-import com.jayway.jsonpath.internal.PathRef;
-import com.jayway.jsonpath.internal.Utils;
+import com.jayway.jsonpath.internal.*;
 import com.jayway.jsonpath.internal.path.PathCompiler;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/Predicate.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Predicate.java
@@ -14,6 +14,7 @@
  */
 package com.jayway.jsonpath;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.spi.mapper.MappingException;
 
 /**
@@ -49,5 +50,8 @@ public interface Predicate {
          * @return configuration
          */
         Configuration configuration();
+        
+
+        AbstractIdentifier getCurrentPath();
     }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/identifier/AbstractIdentifier.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/identifier/AbstractIdentifier.java
@@ -1,0 +1,9 @@
+package com.jayway.jsonpath.identifier;
+
+public abstract class AbstractIdentifier {
+    public abstract String getTagName();
+
+    public abstract AbstractIdentifier getParent();
+
+    public abstract String toString();
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/identifier/ArrayIndexIdentifier.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/identifier/ArrayIndexIdentifier.java
@@ -1,0 +1,14 @@
+package com.jayway.jsonpath.identifier;
+
+public class ArrayIndexIdentifier extends Identifier {
+    final int count;
+
+    public ArrayIndexIdentifier(AbstractIdentifier parent, int count) {
+        super(parent.getTagName(),parent);
+        this.count = count;
+    }
+
+    public String toString(){
+        return parent.toString()+"["+count+"]";
+    }
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/identifier/FunctionIdentifier.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/identifier/FunctionIdentifier.java
@@ -1,0 +1,12 @@
+package com.jayway.jsonpath.identifier;
+
+public class FunctionIdentifier extends Identifier {
+    public FunctionIdentifier(String tagName, AbstractIdentifier parent) {
+        super(tagName, parent);
+    }
+
+    @Override
+    public String toString() {
+        return parent.toString()+"."+tagName;
+    }
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/identifier/Identifier.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/identifier/Identifier.java
@@ -1,0 +1,27 @@
+package com.jayway.jsonpath.identifier;
+
+public  class Identifier extends AbstractIdentifier {
+
+    final String tagName;
+    final AbstractIdentifier parent;
+
+    @Override
+    public String getTagName() {
+        return tagName;
+    }
+
+    @Override
+    public AbstractIdentifier getParent() {
+        return parent;
+    }
+
+    public Identifier(String tagName, AbstractIdentifier parent) {
+        this.tagName = tagName;
+        this.parent = parent;
+    }
+
+    @Override
+    public String toString(){
+        return parent.toString()+"['"+tagName+"']";
+    }
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/identifier/MultiIdentifier.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/identifier/MultiIdentifier.java
@@ -1,0 +1,30 @@
+package com.jayway.jsonpath.identifier;
+
+import com.jayway.jsonpath.internal.Utils;
+
+import java.util.List;
+
+public class MultiIdentifier extends AbstractIdentifier{
+    final List<String> tagNames;
+    final AbstractIdentifier parent;
+
+    public MultiIdentifier(List<String> tagNames, AbstractIdentifier parent) {
+        this.tagNames = tagNames;
+        this.parent = parent;
+    }
+
+    @Override
+    public String getTagName() {
+        return Utils.join(", ", "'", tagNames) ;
+    }
+
+    @Override
+    public AbstractIdentifier getParent() {
+        return parent;
+    }
+
+    @Override
+    public String toString() {
+        return parent.toString() + "["+getTagName()+"]";
+    }
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/identifier/RootIdentifier.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/identifier/RootIdentifier.java
@@ -1,0 +1,12 @@
+package com.jayway.jsonpath.identifier;
+
+public class RootIdentifier extends Identifier{
+
+    public RootIdentifier() {
+        super("$",null);
+    }
+
+    public String toString(){
+        return "$";
+    }
+}

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -14,18 +14,9 @@
  */
 package com.jayway.jsonpath.internal;
 
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.EvaluationListener;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.MapFunction;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.Predicate;
-import com.jayway.jsonpath.ReadContext;
-import com.jayway.jsonpath.TypeRef;
+import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.spi.cache.Cache;
 import com.jayway.jsonpath.spi.cache.CacheProvider;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
@@ -2,10 +2,12 @@ package com.jayway.jsonpath.internal.filter;
 
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Predicate;
-import static com.jayway.jsonpath.internal.filter.ValueNodes.*;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static com.jayway.jsonpath.internal.filter.ValueNodes.PatternNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.ValueListNode;
 
 public class EvaluatorFactory {
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
@@ -4,12 +4,13 @@ import com.jayway.jsonpath.Filter;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.CharacterIndex;
-import static com.jayway.jsonpath.internal.filter.ValueNodes.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.jayway.jsonpath.internal.filter.ValueNodes.*;
 
 public class FilterCompiler  {
     private static final Logger logger = LoggerFactory.getLogger(FilterCompiler.class);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
@@ -1,13 +1,14 @@
 package com.jayway.jsonpath.internal.filter;
 
-import java.util.regex.Pattern;
-
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.path.PathCompiler;
 import net.minidev.json.parser.JSONParser;
+
+import java.util.regex.Pattern;
+
 import static com.jayway.jsonpath.internal.filter.ValueNodes.*;
 
 public abstract class ValueNode {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java
@@ -1,19 +1,6 @@
 package com.jayway.jsonpath.internal.filter;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPathException;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.PathNotFoundException;
-import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.Utils;
 import com.jayway.jsonpath.internal.path.PathCompiler;
@@ -23,6 +10,10 @@ import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * Moved these nodes out of the ValueNode abstract class.

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/PassthruPathFunction.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/PassthruPathFunction.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath.internal.function;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.PathRef;
 
@@ -13,7 +14,7 @@ import java.util.List;
 public class PassthruPathFunction implements PathFunction {
 
     @Override
-    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
+    public Object invoke(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
         return model;
     }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunction.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunction.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath.internal.function;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.PathRef;
 
@@ -32,5 +33,5 @@ public interface PathFunction {
      * @param parameters
      * @return
      */
-    Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters);
+    Object invoke(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters);
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
@@ -2,11 +2,7 @@ package com.jayway.jsonpath.internal.function;
 
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.internal.function.json.Append;
-import com.jayway.jsonpath.internal.function.numeric.Average;
-import com.jayway.jsonpath.internal.function.numeric.Max;
-import com.jayway.jsonpath.internal.function.numeric.Min;
-import com.jayway.jsonpath.internal.function.numeric.StandardDeviation;
-import com.jayway.jsonpath.internal.function.numeric.Sum;
+import com.jayway.jsonpath.internal.function.numeric.*;
 import com.jayway.jsonpath.internal.function.text.Concatenate;
 import com.jayway.jsonpath.internal.function.text.Length;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/json/Append.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/json/Append.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath.internal.function.json;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.function.Parameter;
@@ -16,7 +17,7 @@ import java.util.List;
  */
 public class Append implements PathFunction {
     @Override
-    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
+    public Object invoke(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
         JsonProvider jsonProvider = ctx.configuration().jsonProvider();
         if (parameters != null && parameters.size() > 0) {
             for (Parameter param : parameters) {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -16,7 +16,6 @@ package com.jayway.jsonpath.internal.function.latebinding;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.internal.Path;
-import com.jayway.jsonpath.internal.function.ParamType;
 
 /**
  * Defines the contract for late bindings, provides document state and enough context to perform the evaluation at a later

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
@@ -1,6 +1,7 @@
 package com.jayway.jsonpath.internal.function.numeric;
 
 import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.function.Parameter;
@@ -34,7 +35,7 @@ public abstract class AbstractAggregation implements PathFunction {
     protected abstract Number getValue();
 
     @Override
-    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
+    public Object invoke(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
         int count = 0;
         if(ctx.configuration().jsonProvider().isArray(model)){
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Concatenate.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath.internal.function.text;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.function.Parameter;
@@ -14,7 +15,7 @@ import java.util.List;
  */
 public class Concatenate implements PathFunction {
     @Override
-    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
+    public Object invoke(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
         StringBuilder result = new StringBuilder();
         if(ctx.configuration().jsonProvider().isArray(model)){
             Iterable<?> objects = ctx.configuration().jsonProvider().toIterable(model);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Length.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Length.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath.internal.function.text;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.function.Parameter;
@@ -15,7 +16,7 @@ import java.util.List;
 public class Length implements PathFunction {
 
     @Override
-    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
+    public Object invoke(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
         if(ctx.configuration().jsonProvider().isArray(model)){
             return ctx.configuration().jsonProvider().length(model);
         } else if(ctx.configuration().jsonProvider().isMap(model)){

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayIndexToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayIndexToken.java
@@ -14,9 +14,8 @@
  */
 package com.jayway.jsonpath.internal.path;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
-
-import static java.lang.String.format;
 
 public class ArrayIndexToken extends ArrayPathToken {
 
@@ -27,7 +26,7 @@ public class ArrayIndexToken extends ArrayPathToken {
     }
 
     @Override
-    public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    public void evaluate(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         if (!checkArrayModel(currentPath, model, ctx))
             return;
         if (arrayIndexOperation.isSingleIndexOperation()) {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayPathToken.java
@@ -16,9 +16,7 @@ package com.jayway.jsonpath.internal.path;
 
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.PathNotFoundException;
-import com.jayway.jsonpath.internal.PathRef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 
 import static java.lang.String.format;
 
@@ -33,7 +31,7 @@ public abstract class ArrayPathToken extends PathToken {
      * @throws PathNotFoundException if model is null and evaluation must be interrupted
      * @throws InvalidPathException if model is not an array and evaluation must be interrupted
      */
-    protected boolean checkArrayModel(String currentPath, Object model, EvaluationContextImpl ctx) {
+    protected boolean checkArrayModel(AbstractIdentifier currentPath, Object model, EvaluationContextImpl ctx) {
         if (model == null){
             if (! isUpstreamDefinite()) {
                 return false;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArraySliceToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArraySliceToken.java
@@ -14,6 +14,7 @@
  */
 package com.jayway.jsonpath.internal.path;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +30,7 @@ public class ArraySliceToken extends ArrayPathToken {
     }
 
     @Override
-    public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    public void evaluate(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         if (!checkArrayModel(currentPath, model, ctx))
             return;
         switch (operation.operation()) {
@@ -45,7 +46,7 @@ public class ArraySliceToken extends ArrayPathToken {
         }
     }
 
-    private void sliceFrom(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    private void sliceFrom(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         int length = ctx.jsonProvider().length(model);
         int from = operation.from();
         if (from < 0) {
@@ -64,7 +65,7 @@ public class ArraySliceToken extends ArrayPathToken {
         }
     }
 
-    private void sliceBetween(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    private void sliceBetween(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         int length = ctx.jsonProvider().length(model);
         int from = operation.from();
         int to = operation.to();
@@ -82,7 +83,7 @@ public class ArraySliceToken extends ArrayPathToken {
         }
     }
 
-    private void sliceTo(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    private void sliceTo(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         int length = ctx.jsonProvider().length(model);
         if (length == 0) {
             return;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/CompiledPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/CompiledPath.java
@@ -15,6 +15,7 @@
 package com.jayway.jsonpath.internal.path;
 
 import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.identifier.RootIdentifier;
 import com.jayway.jsonpath.internal.EvaluationAbortException;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.Path;
@@ -96,7 +97,7 @@ public class CompiledPath implements Path {
         EvaluationContextImpl ctx = new EvaluationContextImpl(this, rootDocument, configuration, forUpdate);
         try {
             PathRef op = ctx.forUpdate() ?  PathRef.createRoot(rootDocument) : PathRef.NO_OP;
-            root.evaluate("", op, document, ctx);
+             root.evaluate(new RootIdentifier(), op, document, ctx);
         } catch (EvaluationAbortException abort) {}
 
         return ctx;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
@@ -18,18 +18,14 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.EvaluationListener;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.EvaluationAbortException;
 import com.jayway.jsonpath.internal.EvaluationContext;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static com.jayway.jsonpath.internal.Utils.notNull;
 
@@ -43,7 +39,7 @@ public class EvaluationContextImpl implements EvaluationContext {
     private final Configuration configuration;
     private final Object valueResult;
     private final Object pathResult;
-    private final Path path;
+    public final Path path;
     private final Object rootDocument;
     private final List<PathRef> updateOperations;
     private final HashMap<Path, Object> documentEvalCache = new HashMap<Path, Object>();
@@ -72,19 +68,19 @@ public class EvaluationContextImpl implements EvaluationContext {
         return forUpdate;
     }
 
-    public void addResult(String path, PathRef operation, Object model) {
+    public void addResult(AbstractIdentifier path, PathRef operation, Object model) {
 
         if(forUpdate) {
             updateOperations.add(operation);
         }
 
         configuration.jsonProvider().setArrayIndex(valueResult, resultIndex, model);
-        configuration.jsonProvider().setArrayIndex(pathResult, resultIndex, path);
+        configuration.jsonProvider().setArrayIndex(pathResult, resultIndex, path.toString());
         resultIndex++;
         if(!configuration().getEvaluationListeners().isEmpty()){
             int idx = resultIndex - 1;
             for (EvaluationListener listener : configuration().getEvaluationListeners()) {
-                EvaluationListener.EvaluationContinuation continuation = listener.resultFound(new FoundResultImpl(idx, path, model));
+                EvaluationListener.EvaluationContinuation continuation = listener.resultFound(new FoundResultImpl(idx, path.toString(), model));
                 if(EvaluationListener.EvaluationContinuation.ABORT == continuation){
                     throw ABORT_EVALUATION;
                 }
@@ -147,7 +143,7 @@ public class EvaluationContextImpl implements EvaluationContext {
     public <T> T getPath() {
         if(resultIndex == 0){
             throw new PathNotFoundException("No results for path: " + path.toString());
-        }
+                 }
         return (T)pathResult;
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -1,5 +1,7 @@
 package com.jayway.jsonpath.internal.path;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
+import com.jayway.jsonpath.identifier.FunctionIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.function.Parameter;
 import com.jayway.jsonpath.internal.function.PathFunction;
@@ -34,17 +36,17 @@ public class FunctionPathToken extends PathToken {
     }
 
     @Override
-    public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    public void evaluate(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         PathFunction pathFunction = PathFunctionFactory.newFunction(functionName);
         evaluateParameters(currentPath, parent, model, ctx);
         Object result = pathFunction.invoke(currentPath, parent, model, ctx, functionParams);
-        ctx.addResult(currentPath + "." + functionName, parent, result);
+        ctx.addResult(new FunctionIdentifier(functionName,currentPath), parent, result);
         if (!isLeaf()) {
             next().evaluate(currentPath, parent, result, ctx);
         }
     }
 
-    private void evaluateParameters(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    private void evaluateParameters(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
 
         if (null != functionParams) {
             for (Parameter param : functionParams) {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
@@ -16,8 +16,11 @@ package com.jayway.jsonpath.internal.path;
 
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
+import com.jayway.jsonpath.identifier.ArrayIndexIdentifier;
+import com.jayway.jsonpath.identifier.Identifier;
+import com.jayway.jsonpath.identifier.MultiIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
-import com.jayway.jsonpath.internal.Utils;
 import com.jayway.jsonpath.internal.function.PathFunction;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
@@ -36,11 +39,11 @@ public abstract class PathToken {
         return next;
     }
 
-    void handleObjectProperty(String currentPath, Object model, EvaluationContextImpl ctx, List<String> properties) {
+    void handleObjectProperty(AbstractIdentifier currentPath, Object model, EvaluationContextImpl ctx, List<String> properties) {
 
         if(properties.size() == 1) {
             String property = properties.get(0);
-            String evalPath = Utils.concat(currentPath, "['", property, "']");
+            AbstractIdentifier evalPath = new Identifier(property,currentPath);
             Object propertyVal = readObjectProperty(property, model, ctx);
             if(propertyVal == JsonProvider.UNDEFINED){
                 // Conditions below heavily depend on current token type (and its logic) and are not "universal",
@@ -81,7 +84,7 @@ public abstract class PathToken {
                 next().evaluate(evalPath, pathRef, propertyVal, ctx);
             }
         } else {
-            String evalPath = currentPath + "[" + Utils.join(", ", "'", properties) + "]";
+            AbstractIdentifier evalPath = new MultiIdentifier(properties,currentPath);
 
             assert isLeaf() : "non-leaf multi props handled elsewhere";
 
@@ -122,8 +125,8 @@ public abstract class PathToken {
     }
 
 
-    protected void handleArrayIndex(int index, String currentPath, Object model, EvaluationContextImpl ctx) {
-        String evalPath = Utils.concat(currentPath, "[", String.valueOf(index), "]");
+    protected void handleArrayIndex(int index, AbstractIdentifier currentPath, Object model, EvaluationContextImpl ctx) {
+        AbstractIdentifier evalPath = new ArrayIndexIdentifier(currentPath,index);
         PathRef pathRef = ctx.forUpdate() ? PathRef.create(model, index) : PathRef.NO_OP;
         int effectiveIndex = index < 0 ? ctx.jsonProvider().length(model) + index : index;
         try {
@@ -205,11 +208,11 @@ public abstract class PathToken {
         return super.equals(obj);
     }
 
-    public void invoke(PathFunction pathFunction, String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    public void invoke(PathFunction pathFunction, AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         ctx.addResult(currentPath, parent, pathFunction.invoke(currentPath, parent, model, ctx, null));
     }
 
-    public abstract void evaluate(String currentPath, PathRef parent,  Object model, EvaluationContextImpl ctx);
+    public abstract void evaluate(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx);
 
     public abstract boolean isTokenDefinite();
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PredicateContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PredicateContextImpl.java
@@ -16,6 +16,7 @@ package com.jayway.jsonpath.internal.path;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.spi.mapper.MappingException;
 import org.slf4j.Logger;
@@ -31,12 +32,14 @@ public class PredicateContextImpl implements Predicate.PredicateContext {
     private final Object rootDocument;
     private final Configuration configuration;
     private final HashMap<Path, Object> documentPathCache;
+    private final AbstractIdentifier currentPath;
 
-    public PredicateContextImpl(Object contextDocument, Object rootDocument, Configuration configuration, HashMap<Path, Object> documentPathCache) {
+    public PredicateContextImpl(AbstractIdentifier currentPath, Object contextDocument, Object rootDocument, Configuration configuration, HashMap<Path, Object> documentPathCache) {
         this.contextDocument = contextDocument;
         this.rootDocument = rootDocument;
         this.configuration = configuration;
         this.documentPathCache = documentPathCache;
+        this.currentPath=currentPath;
     }
 
     public Object evaluate(Path path){
@@ -57,6 +60,11 @@ public class PredicateContextImpl implements Predicate.PredicateContext {
 
     public HashMap<Path, Object> documentPathCache() {
         return documentPathCache;
+    }
+    
+    @Override
+    public AbstractIdentifier getCurrentPath() {
+        return currentPath;
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PredicatePathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PredicatePathToken.java
@@ -17,13 +17,13 @@ package com.jayway.jsonpath.internal.path;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
 
 import java.util.Collection;
 import java.util.Collections;
 
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 
 /**
  *
@@ -42,9 +42,9 @@ public class PredicatePathToken extends PathToken {
     }
 
     @Override
-    public void evaluate(String currentPath, PathRef ref, Object model, EvaluationContextImpl ctx) {
+    public void evaluate(AbstractIdentifier currentPath, PathRef ref, Object model, EvaluationContextImpl ctx) {
         if (ctx.jsonProvider().isMap(model)) {
-            if (accept(model, ctx.rootDocument(), ctx.configuration(), ctx)) {
+            if (accept(currentPath,model, ctx.rootDocument(), ctx.configuration(), ctx)) {
                 PathRef op = ctx.forUpdate() ? ref : PathRef.NO_OP;
                 if (isLeaf()) {
                     ctx.addResult(currentPath, op, model);
@@ -57,7 +57,7 @@ public class PredicatePathToken extends PathToken {
             Iterable<?> objects = ctx.jsonProvider().toIterable(model);
 
             for (Object idxModel : objects) {
-                if (accept(idxModel, ctx.rootDocument(),  ctx.configuration(), ctx)) {
+                if (accept(currentPath,idxModel, ctx.rootDocument(),  ctx.configuration(), ctx)) {
                     handleArrayIndex(idx, currentPath, model, ctx);
                 }
                 idx++;
@@ -69,8 +69,8 @@ public class PredicatePathToken extends PathToken {
         }
     }
 
-    public boolean accept(final Object obj, final Object root, final Configuration configuration, EvaluationContextImpl evaluationContext) {
-        Predicate.PredicateContext ctx = new PredicateContextImpl(obj, root, configuration, evaluationContext.documentEvalCache());
+    public boolean accept(AbstractIdentifier currentPath, final Object obj, final Object root, final Configuration configuration, EvaluationContextImpl evaluationContext) {
+        Predicate.PredicateContext ctx = new PredicateContextImpl(currentPath, obj, root, configuration, evaluationContext.documentEvalCache());
 
         for (Predicate predicate : predicates) {
             try {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PropertyPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PropertyPathToken.java
@@ -16,6 +16,7 @@ package com.jayway.jsonpath.internal.path;
 
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
 import com.jayway.jsonpath.internal.Utils;
 
@@ -58,7 +59,7 @@ class PropertyPathToken extends PathToken {
     }
 
     @Override
-    public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    public void evaluate(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         // Can't assert it in ctor because isLeaf() could be changed later on.
         assert onlyOneIsTrueNonThrow(singlePropertyCase(), multiPropertyMergeCase(), multiPropertyIterationCase());
 
@@ -71,7 +72,7 @@ class PropertyPathToken extends PathToken {
                 throw new PathNotFoundException(String.format(
                         "Expected to find an object with property %s in path %s but found '%s'. " +
                         "This is not a json object according to the JsonProvider: '%s'.",
-                        getPathFragment(), currentPath, m, ctx.configuration().jsonProvider().getClass().getName()));
+                        getPathFragment(), currentPath.toString(), m, ctx.configuration().jsonProvider().getClass().getName()));
             }
         }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/RootPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/RootPathToken.java
@@ -14,6 +14,8 @@
  */
 package com.jayway.jsonpath.internal.path;
 
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
+import com.jayway.jsonpath.identifier.RootIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
 
 /**
@@ -54,12 +56,12 @@ public class RootPathToken extends PathToken {
     }
 
     @Override
-    public void evaluate(String currentPath, PathRef pathRef, Object model, EvaluationContextImpl ctx) {
+    public void evaluate(AbstractIdentifier currentPath, PathRef pathRef, Object model, EvaluationContextImpl ctx) {
         if (isLeaf()) {
             PathRef op = ctx.forUpdate() ?  pathRef : PathRef.NO_OP;
-            ctx.addResult(rootToken, op, model);
+            ctx.addResult(new RootIdentifier(), op, model);
         } else {
-            next().evaluate(rootToken, pathRef, model, ctx);
+            next().evaluate(new RootIdentifier(), pathRef, model, ctx);
         }
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/WildcardPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/WildcardPathToken.java
@@ -14,13 +14,12 @@
  */
 package com.jayway.jsonpath.internal.path;
 
-import java.util.Collections;
-
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.PathRef;
 
-import static java.util.Arrays.asList;
+import java.util.Collections;
 
 /**
  *
@@ -31,7 +30,7 @@ public class WildcardPathToken extends PathToken {
     }
 
     @Override
-    public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
+    public void evaluate(AbstractIdentifier currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
         if (ctx.jsonProvider().isMap(model)) {
             for (String property : ctx.jsonProvider().getPropertyKeys(model)) {
                 handleObjectProperty(currentPath, model, ctx, Collections.singletonList(property));

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
@@ -14,12 +14,7 @@
  */
 package com.jayway.jsonpath.spi.json;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
+import com.google.gson.*;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JettisonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JettisonProvider.java
@@ -14,18 +14,13 @@
  */
 package com.jayway.jsonpath.spi.json;
 
+import com.jayway.jsonpath.InvalidJsonException;
+import org.codehaus.jettison.json.JSONException;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-
-import org.codehaus.jettison.json.JSONException;
-import com.jayway.jsonpath.InvalidJsonException;
+import java.util.*;
 
 public class JettisonProvider extends AbstractJsonProvider
 {

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
@@ -1,6 +1,5 @@
 package com.jayway.jsonpath.spi.json;
 
-import org.json.JSONObject;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
 import org.json.JSONArray;

--- a/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
@@ -2,18 +2,8 @@ package com.jayway.jsonpath;
 
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.path.PredicateContextImpl;
-import com.jayway.jsonpath.spi.json.GsonJsonProvider;
-import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.json.JettisonProvider;
-import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
-import com.jayway.jsonpath.spi.json.TapestryJsonProvider;
-import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
-import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;
-import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
-import com.jayway.jsonpath.spi.mapper.TapestryMappingProvider;
+import com.jayway.jsonpath.spi.json.*;
+import com.jayway.jsonpath.spi.mapper.*;
 
 import java.util.HashMap;
 
@@ -120,6 +110,6 @@ public class BaseTest {
 
     public Predicate.PredicateContext createPredicateContext(final Object check) {
 
-        return new PredicateContextImpl(check, check, Configuration.defaultConfiguration(), new HashMap<Path, Object>());
+        return new PredicateContextImpl(null,check, check, Configuration.defaultConfiguration(), new HashMap<Path, Object>());
     }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/Configurations.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Configurations.java
@@ -1,10 +1,6 @@
 package com.jayway.jsonpath;
 
-import com.jayway.jsonpath.spi.json.GsonJsonProvider;
-import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.json.*;
 import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;

--- a/json-path/src/test/java/com/jayway/jsonpath/FilterParseTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/FilterParseTest.java
@@ -1,9 +1,9 @@
 package com.jayway.jsonpath;
 
-import java.util.Collections;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.regex.Pattern;
 
 import static com.jayway.jsonpath.Criteria.where;

--- a/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
@@ -1,6 +1,5 @@
 package com.jayway.jsonpath;
 
-import java.util.ArrayList;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
 

--- a/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
@@ -1,6 +1,5 @@
 package com.jayway.jsonpath;
 
-import com.jayway.jsonpath.internal.ParseContextImpl;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/json-path/src/test/java/com/jayway/jsonpath/PredicateTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PredicateTest.java
@@ -23,4 +23,18 @@ public class PredicateTest extends BaseTest {
 
         assertThat(reader.read("$.store.book[?].isbn", List.class, booksWithISBN)).containsOnly("0-395-19395-8", "0-553-21311-3");
     }
+
+    @Test
+    public void predicates_filters_with_name() {
+        Predicate prefixfilter = new Predicate() {
+            @Override
+            public boolean apply(PredicateContext ctx) {
+                return "abc".equals(ctx.getCurrentPath().getTagName());
+            }
+        };
+
+        Object read = using(GSON_CONFIGURATION).parse("{\"abc\":{\"qwr\":4},\"acd\":2,\"d\":3}").read("$..*[?]",prefixfilter);
+        System.out.println(read);
+        assertThat(read);
+    }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/ProviderInTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/ProviderInTest.java
@@ -2,11 +2,7 @@ package com.jayway.jsonpath;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.gson.JsonArray;
-import com.jayway.jsonpath.spi.json.GsonJsonProvider;
-import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonOrgJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.json.*;
 import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.JsonOrgMappingProvider;

--- a/json-path/src/test/java/com/jayway/jsonpath/TapestryJsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/TapestryJsonProviderTest.java
@@ -1,14 +1,14 @@
 package com.jayway.jsonpath;
 
-import static com.jayway.jsonpath.JsonPath.using;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.tapestry5.json.JSONArray;
+import org.apache.tapestry5.json.JSONObject;
+import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import org.apache.tapestry5.json.JSONArray;
-import org.apache.tapestry5.json.JSONObject;
-import org.junit.Test;
+import static com.jayway.jsonpath.JsonPath.using;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TapestryJsonProviderTest extends BaseTest {
 

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/JsonContextTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/JsonContextTest.java
@@ -1,10 +1,6 @@
 package com.jayway.jsonpath.internal;
 
-import com.jayway.jsonpath.BaseTest;
-import com.jayway.jsonpath.Criteria;
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.Filter;
-import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.*;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/filter/PatternFlagTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/filter/PatternFlagTest.java
@@ -1,7 +1,6 @@
 package com.jayway.jsonpath.internal.filter;
 
 import com.jayway.jsonpath.BaseTest;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/filter/RegexpEvaluatorTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/filter/RegexpEvaluatorTest.java
@@ -12,11 +12,10 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
+import static com.jayway.jsonpath.internal.filter.ValueNode.*;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-
-import static com.jayway.jsonpath.internal.filter.ValueNode.*;
 
 @RunWith(Parameterized.class)
 public class RegexpEvaluatorTest extends BaseTest {

--- a/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
@@ -1,10 +1,6 @@
 package com.jayway.jsonpath.old;
 
-import com.jayway.jsonpath.BaseTest;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.Filter;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;

--- a/json-path/src/test/java/com/jayway/jsonpath/old/IssuesTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/IssuesTest.java
@@ -2,14 +2,8 @@ package com.jayway.jsonpath.old;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.JsonObject;
-import com.jayway.jsonpath.BaseTest;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.Filter;
-import com.jayway.jsonpath.InvalidPathException;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.*;
+import com.jayway.jsonpath.identifier.AbstractIdentifier;
 import com.jayway.jsonpath.internal.Utils;
 import com.jayway.jsonpath.spi.cache.LRUCache;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
@@ -820,6 +814,14 @@ public class IssuesTest extends BaseTest {
 
     private PredicateContext createPredicateContext(final Map<String, Integer> map){
         return new PredicateContext() {
+        
+        
+          @Override
+    public AbstractIdentifier getCurrentPath() {
+        return null;
+    }
+
+            
             @Override
             public Object item() {
                 return map;

--- a/json-path/src/test/java/com/jayway/jsonpath/old/JsonPathTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/JsonPathTest.java
@@ -1,11 +1,6 @@
 package com.jayway.jsonpath.old;
 
-import com.jayway.jsonpath.BaseTest;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.InvalidPathException;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.internal.path.PathCompiler;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;

--- a/json-path/src/test/java/com/jayway/jsonpath/old/internal/ArrayIndexFilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/internal/ArrayIndexFilterTest.java
@@ -1,10 +1,8 @@
 package com.jayway.jsonpath.old.internal;
 
 import com.jayway.jsonpath.JsonPath;
-
-import org.junit.Assert;
-
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;


### PR DESCRIPTION
Added a Identifier Structure, which resembels the old currentPath.
The naming was the best I came up with, as path is already used.

It allows predicates to operate on the current node name/location in the Document.

Using it with ..*[?] or ..[?] seems to be buggy right now, I guess there are some Bugs with scanning and predicates.

Would be glad if this could be added to the library.
This would finally allow stuff like: Match all nodes which match the pattern box* (like box and box123)

Todo: add tests, cleanups, readme