### PR TITLE
Solving issue#399, filters are now accepted in function params

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -271,7 +271,7 @@ public class PathCompiler {
 
         // Parenthesis starts at 1 since we're marking the start of a function call, the close paren will denote the
         // last parameter boundary
-        Integer groupParen = 1, groupBracket = 0, groupBrace = 0, groupQuote = 0;
+        Integer groupParen = 1, groupBracket = 0, groupBrace = 0, groupQuote = 0, filter = 0;
         Boolean endOfStream = false;
         char priorChar = 0;
         List<Parameter> parameters = new ArrayList<Parameter>();
@@ -329,10 +329,18 @@ public class PathCompiler {
                     groupBracket--;
                     break;
 
+                case BEGIN_FILTER:
+                    filter++;
+                    break;
+
                 // In either the close paren case where we have zero paren groups left, capture the parameter, or where
                 // we've encountered a COMMA do the same
                 case CLOSE_PARENTHESIS:
                     groupParen--;
+                    if(filter > 0) {
+                        filter--;
+                        break;
+                    }
                     if (0 != groupParen) {
                         parameter.append(c);
                     }

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue399.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue399.java
@@ -1,0 +1,54 @@
+package com.jayway.jsonpath.internal.function;
+
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ReadContext;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for Issue #399
+ *
+ * Issue#399 states that, if there is a predicate in function call statement, for example $.concat($.store.book[?(@.title)].title,
+ * parsing operation fails due to the unhandled case of filter expressions when parsing parameters of function.
+ * Test case verifies that this issue has been solved.
+ */
+public class Issue399 {
+
+    private String json = "{\n" +
+            "    \"store\": {\n" +
+            "        \"book\": [\n" +
+            "            {\n" +
+            "                \"category\": \"reference\",\n" +
+            "                \"author\": \"Nigel Rees\",\n" +
+            "                \"title\": \"Sayings of the Century\",\n" +
+            "                \"price\": 8.95\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"Evelyn Waugh\",\n" +
+            "                \"title\": \"Sword of Honour\",\n" +
+            "                \"price\": 12.99\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"category\": \"fiction\",\n" +
+            "                \"author\": \"Herman Melville\",\n" +
+            "                \"title\": \"Moby Dick\",\n" +
+            "                \"price\": 8.99\n" +
+            "            }\n" +
+            "        ]\n" +
+            "   }\n" +
+            "}";
+
+    @Test
+    public void testIssue399() {
+        ReadContext ctx = JsonPath.parse(json);
+        String output = ctx.read("$.concat($.store.book[?(@.title)].title, \" - \", $.store.book[?(@.author)].author)");
+        String expected = ctx.read("$.concat($.store.book[*].title, \" - \", $.store.book[*].author)");
+        assertThat(output).isEqualTo(expected);
+
+        double minPriceViaFilter = ctx.read("$.min($.store.book[?(@.price)].price)");
+        double minPriceWildcard = ctx.read("$.min($.store.book[*].price)");
+        assertThat(minPriceViaFilter).isEqualTo(minPriceWildcard);
+    }
+}


### PR DESCRIPTION
Solves the issue#399, where compilation fails if there is a filter expression in function parameter.