### PR TITLE
Upgrade to Hamcrest 2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,7 @@ buildscript {
 ext {
     libs = [
             gson: 'com.google.code.gson:gson:2.8.5',
-            hamcrestCore: 'org.hamcrest:hamcrest-core:1.3',
-            hamcrestLibrary: 'org.hamcrest:hamcrest-library:1.3',
+            hamcrest: 'org.hamcrest:hamcrest:2.1',
             jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.9.8',
             jettison: 'org.codehaus.jettison:jettison:1.3.7',
             jsonOrg: 'org.json:json:20140107',
@@ -25,8 +24,7 @@ ext {
                     'commons-io:commons-io:2.4',
                     'junit:junit:4.12',
                     'org.assertj:assertj-core:3.11.1',
-                    'org.hamcrest:hamcrest-core:1.3',
-                    'org.hamcrest:hamcrest-library:1.3',
+                    'org.hamcrest:hamcrest:2.1',
                     'org.slf4j:slf4j-simple:1.7.26'
             ]
     ]

--- a/json-path-assert/build.gradle
+++ b/json-path-assert/build.gradle
@@ -11,8 +11,7 @@ jar {
 
 dependencies {
     compile project(':json-path')
-    compile libs.hamcrestCore
-    compile libs.hamcrestLibrary
+    compile libs.hamcrest
     compile libs.slf4jApi
 
     testCompile libs.test

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsCollectionWithSize.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsCollectionWithSize.java
@@ -30,7 +30,6 @@ DAMAGE.
 package com.jayway.jsonassert.impl.matcher;
 
 import org.hamcrest.Description;
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 
 import java.util.Collection;
@@ -52,6 +51,7 @@ public class IsCollectionWithSize<E> extends CollectionMatcher<Collection<? exte
         return sizeMatcher.matches(item.size());
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("a collection with size ")
             .appendDescriptionOf(sizeMatcher);
@@ -60,7 +60,6 @@ public class IsCollectionWithSize<E> extends CollectionMatcher<Collection<? exte
     /**
      * Does collection size satisfy a given matcher?
      */
-    @Factory
     public static <E> Matcher<? super Collection<? extends E>> hasSize(Matcher<? super Integer> size) {
         return new IsCollectionWithSize<E>(size);
     }
@@ -71,7 +70,6 @@ public class IsCollectionWithSize<E> extends CollectionMatcher<Collection<? exte
      * For example,  assertThat(hasSize(equal_to(x)))
      *          vs.  assertThat(hasSize(x))
      */
-    @Factory
     public static <E> Matcher<? super Collection<? extends E>> hasSize(int size) {
         Matcher<? super Integer> matcher = equalTo(size);
         return IsCollectionWithSize.<E>hasSize(matcher);

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsEmptyCollection.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsEmptyCollection.java
@@ -30,7 +30,6 @@ DAMAGE.
 package com.jayway.jsonassert.impl.matcher;
 
 import org.hamcrest.Description;
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 
 import java.util.Collection;
@@ -45,6 +44,7 @@ public class IsEmptyCollection<E> extends CollectionMatcher<Collection<E>> {
         return item.isEmpty();
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("an empty collection");
     }
@@ -52,7 +52,6 @@ public class IsEmptyCollection<E> extends CollectionMatcher<Collection<E>> {
     /**
      * Matches an empty collection.
      */
-    @Factory
     public static <E> Matcher<Collection<E>> empty() {
         return new IsEmptyCollection<E>();
     }

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingKey.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingKey.java
@@ -30,7 +30,6 @@ DAMAGE.
 package com.jayway.jsonassert.impl.matcher;
 
 import org.hamcrest.Description;
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 
 import java.util.Map;
@@ -54,17 +53,16 @@ public class IsMapContainingKey<K> extends MapTypeSafeMatcher<Map<K,?>> {
         return false;
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("map with key ")
                    .appendDescriptionOf(keyMatcher);
     }
 
-    @Factory
     public static <K> Matcher<Map<K,?>> hasKey(K key) {
         return hasKey(equalTo(key));
     }
 
-    @Factory
     public static <K> Matcher<Map<K,?>> hasKey(Matcher<K> keyMatcher) {
         return new IsMapContainingKey<K>(keyMatcher);
     }

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingValue.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/IsMapContainingValue.java
@@ -30,7 +30,6 @@ DAMAGE.
 package com.jayway.jsonassert.impl.matcher;
 
 import org.hamcrest.Description;
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 
 import java.util.Map;
@@ -54,17 +53,16 @@ public class IsMapContainingValue<V> extends MapTypeSafeMatcher<Map<?,V>>{
         return false;
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("map with value ")
                    .appendDescriptionOf(valueMatcher);
     }
 
-    @Factory
     public static <V> Matcher<? super Map<?,V>> hasValue(V value) {
         return IsMapContainingValue.<V>hasValue(equalTo(value));
     }
 
-    @Factory
     public static <V> Matcher<? super Map<?,V>> hasValue(Matcher<? super V> valueMatcher) {
         return new IsMapContainingValue<V>(valueMatcher);
     }


### PR DESCRIPTION
https://github.com/hamcrest/JavaHamcrest/releases/tag/v2.1:
"After a long hiatus without releases, this version simplifies the packaging of
Hamcrest into a single jar: hamcrest-2.1.jar. Other big changes include
Java 9 module compatibility, along with numerous other improvements and bug
fixes."