### PR TITLE
Fix for issue #582 -- NullPointerException of JsonProvider.length()

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
@@ -153,7 +153,8 @@ public abstract class AbstractJsonProvider implements JsonProvider {
         } else if(obj instanceof String){
             return ((String)obj).length();
         }
-        throw new JsonPathException("length operation cannot be applied to " + obj!=null?obj.getClass().getName():"null");
+        throw new JsonPathException("length operation cannot be applied to " + (obj != null ? obj.getClass().getName()
+                : "null"));
     }
 
     /**

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
@@ -246,9 +246,8 @@ public class GsonJsonProvider extends AbstractJsonProvider {
                 }
             }
         }
-
-        throw new JsonPathException("length operation can not applied to " + obj != null ? obj.getClass().getName()
-                                                                                         : "null");
+        throw new JsonPathException("length operation can not applied to " + (obj != null ? obj.getClass().getName()
+                                                                                         : "null"));
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
@@ -211,7 +211,8 @@ public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
                 return element.size();
             }
         }
-        throw new JsonPathException("length operation can not applied to " + obj != null ? obj.getClass().getName() : "null");
+        throw new JsonPathException("length operation can not applied to " + (obj != null ? obj.getClass().getName()
+                : "null"));
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
@@ -170,7 +170,8 @@ public class JsonOrgJsonProvider extends AbstractJsonProvider {
                 return ((String) obj).length();
             }
         }
-        throw new JsonPathException("length operation can not applied to " + obj != null ? obj.getClass().getName() : "null");
+        throw new JsonPathException("length operation can not applied to " + (obj != null ? obj.getClass().getName()
+                : "null"));
     }
 
     @Override


### PR DESCRIPTION
## Changes:
* Enclose `obj != null ? obj.getClass().getName() : "null"` with brackets, avoiding condition `obj != null` always being `true`