### PR TITLE
fix issue #565 and add testcase

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
@@ -113,7 +113,7 @@ public class EvaluationContextImpl implements EvaluationContext {
 
     public Collection<PathRef> updateOperations(){
 
-        Collections.sort(updateOperations);
+        Collections.reverse(updateOperations);
 
         return Collections.unmodifiableCollection(updateOperations);
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/issue/Issue565.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/issue/Issue565.java
@@ -1,0 +1,37 @@
+package com.jayway.jsonpath.issue;
+
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ReadContext;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class Issue565 {
+
+    @Test
+    public void test_issue_565() {
+        String json = "{\n" +
+                "  \"oldName\": {\n" +
+                "    \"oldName\": {\n" +
+                "      \"oldName\": {\n" +
+                "        \"otherName\": \"value\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        String jsonPath = "$..[?(@.oldName)]";
+        String oldKeyName = "oldName";
+        String newKeyName = "newName";
+        ReadContext context = JsonPath.parse(json).renameKey(jsonPath, oldKeyName, newKeyName);
+        List<Object> result = context.read("$..[?(@.newName)]");
+
+        assertEquals(3, result.size());
+
+        assertNotNull(context.read("$.newName"));
+        assertNotNull(context.read("$.newName.newName"));
+        assertNotNull(context.read("$.newName.newName.newName"));
+    }
+}


### PR DESCRIPTION
## Changes:
* fix for issue #565 
* reverse `updateOperations` instead of sorting it,  when nested object has the same keyName, it could normally rename all the same keyName.