### PR TITLE
Add escape to path string

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PropertyPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PropertyPathToken.java
@@ -97,9 +97,19 @@ class PropertyPathToken extends PathToken {
 
     @Override
     public String getPathFragment() {
+        // Add escape characters to string of property paths that it can be recompile to JsonPath
+        List<String> outputProperties = new ArrayList<String>(properties.size());
+        for (String property : properties) {
+            String outputProperty = property
+                    // "\" to "\\"
+                    .replaceAll("\\\\", "\\\\\\\\")
+                    // "'" to "\'"
+                    .replaceAll("'", "\\\\'");
+            outputProperties.add(outputProperty);
+        }
         return new StringBuilder()
                 .append("[")
-                .append(Utils.join(",", stringDelimiter, properties))
+                .append(Utils.join(",", stringDelimiter, outputProperties))
                 .append("]").toString();
     }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
@@ -323,4 +323,27 @@ public class PathCompilerTest {
     public void property_must_be_separated_by_commas() {
         compile("$['aaa'}'bbb']");
     }
+
+    @Test
+    public void property_with_escape_characters() {
+        String json = "{\n"
+                + "    \"a']['b\": 1,\n"
+                + "    \"\\\\']['b\": 2\n"
+                + "}";
+        DocumentContext parse = JsonPath.parse(json);
+
+        JsonPath compile1 = JsonPath.compile("$['a\\'][\\'b']");
+        int result1 = parse.read(compile1);
+        assertThat(result1).isEqualTo(1);
+
+        JsonPath compile2 = JsonPath.compile("$['\\\\\\'][\\'b']");
+        int result2 = parse.read(compile2);
+        assertThat(result2).isEqualTo(2);
+
+        // not "$['a']['b']"
+        assertThat(compile("$['a\\'][\\'b']").toString()).isEqualTo("$['a\\'][\\'b']");
+
+        // not "$['\']['b']"
+        assertThat(compile("$['\\\\\\'][\\'b']").toString()).isEqualTo("$['\\\\\\'][\\'b']");
+    }
 }


### PR DESCRIPTION
The instance method of JsonPath.getPath() returns a string without escape characters. Sometimes it may returns a error path string.
For example, consider the following json:

String json = "{\"a']['b\": 1}";

DocumentContext parse = JsonPath.parse(json);
JsonPath compile = JsonPath.compile("$['a\\'][\\'b']");
int result = parse.read(compile);

// output 1
System.out.println(result);

// output the wrong path "$['a']['b']"
System.out.println(compile.getPath());

Consider another example:

String json = "{\"'a'\": 1}";
DocumentContext parse = JsonPath.parse(json);
JsonPath compile = JsonPath.compile("$['\\'a\\'']");
int result = parse.read(compile);

// output 1
System.out.println(result);

// output the path "$[''a'']"
System.out.println(compile.getPath());

// it will throw an InvalidPathException
JsonPath compile2 = JsonPath.compile(compile.getPath());

This issue has been fixed in this commit. The instance method of JsonPath.getPath() will returns the right path which can be recompile to JsonPath.