### PR TITLE
Support array of string with numbers for aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The function output is dictated by the function itself.
 | avg()                     | Provides the average value of an array of numbers                   | Double    |
 | stddev()                  | Provides the standard deviation value of an array of numbers        | Double    |
 | length()                  | Provides the length of an array                                     | Integer   |
+| sum()                     | Provides the sum value of an array of numbers                                    | Integer   |
 
 
 Filter Operators

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The function output is dictated by the function itself.
 | avg()                     | Provides the average value of an array of numbers                   | Double    |
 | stddev()                  | Provides the standard deviation value of an array of numbers        | Double    |
 | length()                  | Provides the length of an array                                     | Integer   |
-| sum()                     | Provides the sum value of an array of numbers                                    | Integer   |
+| sum()                     | Provides the sum value of an array of numbers                       | Integer   |
 
 
 Filter Operators

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The function output is dictated by the function itself.
 | avg()                     | Provides the average value of an array of numbers                   | Double    |
 | stddev()                  | Provides the standard deviation value of an array of numbers        | Double    |
 | length()                  | Provides the length of an array                                     | Integer   |
-| sum()                     | Provides the sum value of an array of numbers                       | Integer   |
+| sum()                     | Provides the sum value of an array of numbers                       | Double    |
 
 
 Filter Operators

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/AbstractAggregation.java
@@ -7,6 +7,7 @@ import com.jayway.jsonpath.internal.function.Parameter;
 import com.jayway.jsonpath.internal.function.PathFunction;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Defines the pattern for processing numerical values via an abstract implementation that iterates over the collection
@@ -16,6 +17,8 @@ import java.util.List;
  * Created by mattg on 6/26/15.
  */
 public abstract class AbstractAggregation implements PathFunction {
+
+    private final static Pattern NUMBERS_PATTERN = Pattern.compile("-?\\d+(\\.\\d+)?");
 
     /**
      * Defines the next value in the array to the mathmatical function
@@ -40,6 +43,11 @@ public abstract class AbstractAggregation implements PathFunction {
 
             Iterable<?> objects = ctx.configuration().jsonProvider().toIterable(model);
             for (Object obj : objects) {
+                if (obj instanceof String && isNumeric((String) obj)) {
+                    Number value = Double.parseDouble((String) obj);
+                    count++;
+                    next(value);
+                }
                 if (obj instanceof Number) {
                     Number value = (Number) obj;
                     count++;
@@ -57,5 +65,18 @@ public abstract class AbstractAggregation implements PathFunction {
             return getValue();
         }
         throw new JsonPathException("Aggregation function attempted to calculate value using empty array");
+    }
+
+    /**
+     * Returns true if specified string is numeric value.
+     *
+     * @param strNum string to check
+     * @return true if numeric
+     */
+    private boolean isNumeric(final String strNum) {
+        if (strNum == null) {
+            return false;
+        }
+        return NUMBERS_PATTERN.matcher(strNum).matches();
     }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/BaseFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/BaseFunctionTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by mattg on 6/27/15.
  */
 public class BaseFunctionTest {
-    protected static final String NUMBER_SERIES = "{\"empty\": [], \"numbers\" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}";
+    protected static final String NUMBER_SERIES = "{\"empty\": [], \"numbers\" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], \"string_numbers\" : [ \"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", \"9\", \"10\"]}";
     protected static final String TEXT_SERIES = "{\"urls\": [\"http://api.worldbank.org/countries/all/?format=json\", \"http://api.worldbank.org/countries/all/?format=json\"], \"text\" : [ \"a\", \"b\", \"c\", \"d\", \"e\", \"f\" ]}";
 
     /**

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
@@ -84,7 +84,15 @@ public class NestedFunctionTest extends BaseFunctionTest {
      */
     @Test
     public void testAppendTextAndNumberThenSum() {
-        verifyMathFunction(conf, "$.numbers.append(\"0\", \"11\").sum()", 55.0);
+        verifyMathFunction(conf, "$.numbers.append(\"str\", \"str2\").sum()", 55.0);
+    }
+
+    /**
+     * n
+     */
+    @Test
+    public void testAppendStringNumberAndNumberThenSum() {
+        verifyMathFunction(conf, "$.numbers.append(\"0\", \"11\").sum()", 66.0);
     }
 
     @Test

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/NumericPathFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/NumericPathFunctionTest.java
@@ -62,6 +62,11 @@ public class NumericPathFunctionTest extends BaseFunctionTest {
     }
 
     @Test
+    public void testSumOfStringDouble() {
+        verifyMathFunction(conf, "$.string_numbers.sum()", (10d * (10d + 1d)) / 2d);
+    }
+
+    @Test
     public void testSumOfEmptyListNegative() {
         try {
             verifyMathFunction(conf, "$.empty.sum()", null);


### PR DESCRIPTION
I faced the issue when some numeric data is presented as string in json and current aggregations doesn't support it.

For example, I have the following json:
```
{
  "distance": [
    "44.5",
    "32.2",
    "11.1",
    "5.0"
  ]
}
```
And I try to calculate sum aggregation for this field:
```
$.distance.sum()
```

It causes error: "Aggregation function attempted to calculate value using empty array".

To avoid this I've added condition for numbers which are presented as string in `AbstractAggregation`. I didn't use exception based logic and another libraries and just used regexp, please tell me if you have any other ideas on how to check this in more better way.

P.S. Don't ask me why I work with json where digits are presented as strings... it's not up to me but I think it can help someone.