### PR TITLE
Avoid InvalidPathException in RelationalOperator, fixes #600

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalOperator.java
@@ -2,6 +2,8 @@ package com.jayway.jsonpath.internal.filter;
 
 import com.jayway.jsonpath.InvalidPathException;
 
+import java.util.Locale;
+
 public enum RelationalOperator {
 
     GTE(">="),
@@ -40,9 +42,10 @@ public enum RelationalOperator {
         this.operatorString = operatorString;
     }
 
-    public static RelationalOperator fromString(String operatorString){
+    public static RelationalOperator fromString(String operatorString) {
+        String upperCaseOperatorString = operatorString.toUpperCase(Locale.ROOT);
         for (RelationalOperator operator : RelationalOperator.values()) {
-            if(operator.operatorString.equals(operatorString.toUpperCase()) ){
+            if(operator.operatorString.equals(upperCaseOperatorString) ){
                 return operator;
             }
         }

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/filter/RelationalOperatorTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/filter/RelationalOperatorTest.java
@@ -1,0 +1,39 @@
+package com.jayway.jsonpath.internal.filter;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+
+public class RelationalOperatorTest {
+
+    Locale locale;
+
+    @Before
+    public void saveDefaultLocale() {
+        locale = Locale.getDefault();
+    }
+
+    @After
+    public void restoreDefaultLocale() {
+        Locale.setDefault(locale);
+    }
+
+    @Test
+    public void testFromStringWithEnglishLocale() {
+        Locale.setDefault(Locale.ENGLISH);
+        assertEquals(RelationalOperator.IN, RelationalOperator.fromString("in"));
+        assertEquals(RelationalOperator.IN, RelationalOperator.fromString("IN"));
+    }
+
+    @Test
+    public void testFromStringWithTurkishLocale() {
+        Locale.setDefault(new Locale("tr", "TR"));
+        assertEquals(RelationalOperator.IN, RelationalOperator.fromString("in"));
+        assertEquals(RelationalOperator.IN, RelationalOperator.fromString("IN"));
+    }
+
+}


### PR DESCRIPTION
This fixes #600 by passing `Locale.ROOT` to operatorString.toUpperCase()

I also pulled the call to `toUpperCase` out of the for-loop, which brings the time for 100k calls to RelationalOperator.fromString("IN") from 75ms down to 12ms on my machine.


