### PR TITLE
Automatic module names for Java 9+ modules

### DIFF
--- a/json-path-assert/build.gradle
+++ b/json-path-assert/build.gradle
@@ -5,7 +5,7 @@ description = "Assertions on Json using JsonPath"
 jar {
     baseName 'json-path-assert'
     manifest {
-        attributes 'Implementation-Title': 'json-path-assert', 'Implementation-Version': version
+        attributes 'Implementation-Title': 'json-path-assert', 'Implementation-Version': version, 'Automatic-Module-Name': 'jayway.jsonpath.pathassert'
     }
 }
 

--- a/json-path-web-test/build.gradle
+++ b/json-path-web-test/build.gradle
@@ -21,7 +21,8 @@ jar {
     manifest {
         attributes 'Implementation-Title': 'json-path-web-test',
                    'Implementation-Version': version,
-                   'Main-Class': mainClassName
+                   'Main-Class': mainClassName,
+                   'Automatic-Module-Name': 'jayway.jsonpath.webtest'
     }
 }
 

--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -5,7 +5,7 @@ description = "Java port of Stefan Goessner JsonPath."
 jar {
     baseName 'json-path'
     manifest {
-        attributes 'Implementation-Title': 'json-path', 'Implementation-Version': version
+        attributes 'Implementation-Title': 'json-path', 'Implementation-Version': version, 'Automatic-Module-Name': 'jayway.jsonpath.path'
         instruction 'Import-Package', 'org.json.*;resolution:=optional', 'com.google.gson.*;resolution:=optional', 'com.fasterxml.jackson.*;resolution:=optional', 'org.apache.tapestry5.json.*;resolution:=optional', 'org.codehaus.jettison.*;resolution:=optional', '*'
     }
 }


### PR DESCRIPTION
`assert` is a reserved keyword in Java and indeed also in
module-info.java (Java module system), therefore the automatic
jar-to-module convert fails and when using the library with a Java
module, the compiler can not find the classes, as the module name
errors.

This added the standardized attribute in the manifest for naming the
module, and does not modularize the code as such. It does allow the
library to be used from Java 9+ modules.

There should be no effect on Java 8 and below.

An example of the compiler warning (from maven-compiler-plugin):
```
[INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ pkgd-repository-jdbc ---
[WARNING] Can't extract module name from json-path-assert-2.4.0.jar: json.path.assert: Invalid module name: 'assert' is not a Java identifier
```

https://openjdk.java.net/projects/jigsaw/spec/sotms/#automatic-modules