### PR TITLE
Fix issue #599：Read as list will throws an ClassCastException when using GsonJsonProvider 

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -24,6 +24,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.jayway.jsonpath.Option.ALWAYS_RETURN_LIST;
 import static com.jayway.jsonpath.Option.AS_PATH_LIST;
@@ -181,10 +183,32 @@ public class JsonPath {
 
             } else {
                 Object res = path.evaluate(jsonObject, jsonObject, configuration).getValue(false);
-                if (optAlwaysReturnList && path.isDefinite()) {
-                    Object array = configuration.jsonProvider().createArray();
-                    configuration.jsonProvider().setArrayIndex(array, 0, res);
-                    return (T) array;
+                if (optAlwaysReturnList) {
+                    List list = new ArrayList();
+                    if (path.isDefinite()) {
+                        Object array = configuration.jsonProvider().createArray();
+                        configuration.jsonProvider().setArrayIndex(array, 0, res);
+                        if (!(array instanceof List)) {
+                            if (array instanceof Iterable) {
+                                for (T item : (Iterable<? extends T>) array) {
+                                    list.add(item);
+                                }
+                            }
+                        } else {
+                            list = (List) array;
+                        }
+                    } else {
+                        if (!(res instanceof List)) {
+                            if (res instanceof Iterable) {
+                                for (T item : (Iterable<? extends T>) res) {
+                                    list.add(item);
+                                }
+                            }
+                        } else {
+                            list = (List) res;
+                        }
+                    }
+                    return (T) list;
                 } else {
                     return (T) res;
                 }

--- a/json-path/src/test/java/com/jayway/jsonpath/issue/Issue599.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/issue/Issue599.java
@@ -1,0 +1,44 @@
+package com.jayway.jsonpath.issue;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue599 {
+
+    @Test
+    public void test_issue_599() {
+        String json = "[" +
+                    "{\n" +
+                    "   \"name\": \"Jack\",\n" +
+                    "   \"gender\": \"male\"\n" +
+                    "}, " +
+                    "{\n" +
+                    "   \"name\": \"Lisa\",\n" +
+                    "   \"gender\": \"female\"\n" +
+                    "}" +
+                "]";
+        Configuration config = Configuration.builder().options(Option.ALWAYS_RETURN_LIST)
+                .jsonProvider(new GsonJsonProvider()).mappingProvider(new GsonMappingProvider()).build();
+        DocumentContext ctx = JsonPath.parse(json, config);
+
+        // Gson will parse a node as JsonPrimitive
+        List<JsonPrimitive> list = ctx.read("$[*].name");
+        assertThat(list).isInstanceOf(List.class);
+
+        JsonElement element1 = new JsonPrimitive("Jack");
+        JsonElement element2 = new JsonPrimitive("Lisa");
+        assertThat(list.get(0)).isEqualTo(element1);
+        assertThat(list.get(1)).isEqualTo(element2);
+    }
+}


### PR DESCRIPTION
when option `ALWAYS_RETURN_LIST` is set, reading path will return gson.JsonArray, however, JsonArray is not implemented `List`, so it can't be casted to `List`.