### PR TITLE
Mark json-smart as optional in the manifest file for OSGI (issue #626)

### DIFF
--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -6,7 +6,7 @@ jar {
     baseName 'json-path'
     manifest {
         attributes 'Implementation-Title': 'json-path', 'Implementation-Version': version
-        instruction 'Import-Package', 'org.json.*;resolution:=optional', 'com.google.gson.*;resolution:=optional', 'com.fasterxml.jackson.*;resolution:=optional', 'org.apache.tapestry5.json.*;resolution:=optional', 'org.codehaus.jettison.*;resolution:=optional', '*'
+        instruction 'Import-Package', 'org.json.*;resolution:=optional', 'com.google.gson.*;resolution:=optional', 'com.fasterxml.jackson.*;resolution:=optional', 'org.apache.tapestry5.json.*;resolution:=optional', 'org.codehaus.jettison.*;resolution:=optional', 'net.minidev.*;resolution:=optional','*'
     }
 }
 


### PR DESCRIPTION
References issue #626 