### PR TITLE
Only look for PatternFlags after a regular expression

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
@@ -274,17 +274,32 @@ public class FilterCompiler  {
 
     }
 
+    private int endOfFlags(int position) {
+        int endIndex = position;
+        char[] currentChar = new char[1];
+        while (filter.inBounds(endIndex)) {
+            currentChar[0] = filter.charAt(endIndex);
+            if (PatternFlag.parseFlags(currentChar) > 0) {
+                endIndex++;
+                continue;
+            }
+            break;
+        }
+        return endIndex;
+    }
+
     private PatternNode readPattern() {
         int begin = filter.position();
         int closingIndex = filter.nextIndexOfUnescaped(PATTERN);
         if (closingIndex == -1) {
             throw new InvalidPathException("Pattern not closed. Expected " + PATTERN + " in " + filter);
         } else {
-            if(filter.inBounds(closingIndex+1)) {
-                int equalSignIndex = filter.nextIndexOf('=');
-                int endIndex = equalSignIndex > closingIndex ? equalSignIndex : filter.nextIndexOfUnescaped(CLOSE_PARENTHESIS);
-                CharSequence flags = filter.subSequence(closingIndex + 1, endIndex);
-                closingIndex += flags.length();
+            if (filter.inBounds(closingIndex+1)) {
+                int endFlagsIndex = endOfFlags(closingIndex + 1);
+                if (endFlagsIndex > closingIndex) {
+                    CharSequence flags = filter.subSequence(closingIndex + 1, endFlagsIndex);
+                    closingIndex += flags.length();
+                }
             }
             filter.setPosition(closingIndex + 1);
         }

--- a/json-path/src/test/java/com/jayway/jsonpath/InlineFilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/InlineFilterTest.java
@@ -211,6 +211,16 @@ public class InlineFilterTest extends BaseTest {
     }
 
     @Test
+    public void escape_pattern_after_literal() {
+        assertHasOneResult("[\"x\"]", "$[?(@ == \"abc\" || @ =~ /\\/|x/)]", conf);
+    }
+
+    @Test
+    public void escape_pattern_before_literal() {
+        assertHasOneResult("[\"x\"]", "$[?(@ =~ /\\/|x/ || @ == \"abc\")]", conf);
+    }
+
+    @Test
     public void filter_evaluation_does_not_break_path_evaluation() {
         assertHasOneResult("[{\"s\": \"fo\", \"expected_size\": \"m\"}, {\"s\": \"lo\", \"expected_size\": 2}]", "$[?(@.s size @.expected_size)]", conf);
     }


### PR DESCRIPTION
As described in #658, the current implementation doesn't work on a logical expression after
an regex like

  `?(@ =~ /something/ || @ == "abc")`

This issue has been introduced with the handling of PatternFlags in cbdc9c82e00edb9496f41a4aca3d12ef7ee8321b
The parser should only look for valid PatternFlag chars after the closing slash. It would be nice,
if the PatternFlag enum could return the available flags as chars (or even better a set of chars?). That would
make looking for the next non-flag char easier. (Maybe even add a method to CharacterIndex to find the next
char not in a given set?)