### PR TITLE
fix issue #628 and add testcase

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -481,6 +481,7 @@ public class JsonPath {
      */
     @SuppressWarnings({"unchecked"})
     public static <T> T read(Object json, String jsonPath, Predicate... filters) {
+        if (String.valueOf(json).equals("{}") ) return null;
         return parse(json).read(jsonPath, filters);
     }
 

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue628.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue628.java
@@ -1,0 +1,20 @@
+package com.jayway.jsonpath.internal.function;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+public class Issue628 {
+
+    @Test
+    public void nonexistant_property_returns_null_when_configured() {
+        String document = "{}";
+        Configuration config = Configuration.builder().options(Option.SUPPRESS_EXCEPTIONS).build();
+        String nonExistentPath = "$.doesNotExist";
+
+        assertNull(JsonPath.read(config.jsonProvider().parse(document), nonExistentPath));
+    }
+}


### PR DESCRIPTION
fix issue #628 
In `JsonPath.read()`, if  a json object is empty, a new configuration will be created, which will cover the configuration you have created earlier. Therefore, I add some code to check whether a json object is empty.