### PR TITLE
#687 update json-smart to fix CVE-2021-27568

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
             jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.11.3',
             jettison: 'org.codehaus.jettison:jettison:1.4.1',
             jsonOrg: 'org.json:json:20140107',
-            jsonSmart: 'net.minidev:json-smart:2.3',
+            jsonSmart: 'net.minidev:json-smart:2.4.2',
             slf4jApi: 'org.slf4j:slf4j-api:1.7.30',
             tapestryJson: 'org.apache.tapestry:tapestry-json:5.6.1',
 


### PR DESCRIPTION
CVE-2021-27568 has been fixed in latest releases of json-smart library. This will help with security violation in all projects that use JsonPath.