### PR TITLE
Fix the issue 663 and add two testcases

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -52,7 +52,7 @@ public class FunctionPathToken extends PathToken {
                     switch (param.getType()) {
                         case PATH:
                             param.setLateBinding(new PathLateBindingValue(param.getPath(), ctx.rootDocument(), ctx.configuration()));
-                            param.setEvaluated(true);
+//                            param.setEvaluated(true);
                             break;
                         case JSON:
                             param.setLateBinding(new JsonLateBindingValue(ctx.configuration().jsonProvider(), param));

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue663.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue663.java
@@ -1,0 +1,60 @@
+package com.jayway.jsonpath.internal.function;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue663 {
+    @Test
+    public void testJsonPathCacheWithSumFunction() {
+        String jsonString = "{\r\n"
+                + "\"total\":1,\r\n"
+                + "\"data\":[\r\n"
+                + " {\r\n"
+                + "\"client_count\":358\r\n"
+                + " }\r\n"
+                + " ]\r\n"
+                + "}";
+        double value1 = JsonPath.read(jsonString, "$.sum($..client_count)");
+        assertEquals(358, value1, 0);
+
+        String jsonString2 = "{\r\n"
+                + "\"total\":1,\r\n"
+                + "\"data\":[\r\n"
+                + " {\r\n"
+                + "\"client_count\":308\r\n"
+                + " }\r\n"
+                + " ]\r\n"
+                + "}";
+        double value2 = JsonPath.read(jsonString2, "$.sum($..client_count)");
+        assertEquals(308, value2, 0);
+    }
+
+    @Test
+    public void testJsonPathCacheWithMaxFunction() {
+        String jsonString = "{\r\n"
+                + "\"total\":1,\r\n"
+                + "\"data\":[\r\n"
+                + " {\r\n"
+                + "\"client_count\":358\r\n"
+                + " }\r\n"
+                + " ]\r\n"
+                + "}";
+        double value1 = JsonPath.read(jsonString, "$.max($..client_count)");
+        assertEquals(358, value1, 0);
+
+        String jsonString2 = "{\r\n"
+                + "\"total\":1,\r\n"
+                + "\"data\":[\r\n"
+                + " {\r\n"
+                + "\"client_count\":308\r\n"
+                + " }\r\n"
+                + " ]\r\n"
+                + "}";
+        double value2 = JsonPath.read(jsonString2, "$.max($..client_count)");
+        assertEquals(308, value2, 0);
+    }
+}


### PR DESCRIPTION
Fix the issue [663](https://github.com/json-path/JsonPath/issues/663) that JsonPath.read() method with the same path for different json content returns the same result.