### PR TITLE
Fixed issue #677, add a testcase for issue #677 and add a testcase for issue #692

### DIFF
--- a/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/FilterTest.java
@@ -558,4 +558,19 @@ public class FilterTest extends BaseTest {
         List list = JsonPath.read(JSON_DOCUMENT, "$.store.book[?(@.category in ['reference', 'fiction'])]");
         assertThat(list).hasSize(4);
     }
+
+    @Test
+    // https://github.com/jayway/JsonPath/issues/692
+    public void testFilterWithAndCondition() {
+        //String simpleJson = "{ \"a\":\"bcd\" }";
+        //ReadContext context = JsonPath.parse(simpleJson);
+        Filter filter1 = Filter.parse("[?((($.a == 'bcd') && ($.a =~ /b.*/)))]");   // Valid according to the issue;
+        Filter filter2 = Filter.parse("[?((($.a =~ /b.*/) && ($.a =~ /b.*/)))]");   // Invalid.
+        Filter filter3 = Filter.parse("[?((($.a == 'bcd') && ($.a == 'bcd')))]");
+        Filter filter4 = Filter.parse("[?((($.a =~ /b.*/) && ($.a == 'bcd')))]");
+        Filter filter5 = Filter.parse("[?((($.a == 'bcd') || ($.a =~ /b.*/)))]");
+        Filter filter6 = Filter.parse("[?((($.a =~ /b.*/) || ($.a =~ /b.*/)))]");
+        Filter filter7 = Filter.parse("[?((($.a == 'bcd') || ($.a == 'bcd')))]");
+        Filter filter8 = Filter.parse("[?((($.a =~ /b.*/) || ($.a == 'bcd')))]");
+    }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PathCompilerTest.java
@@ -323,4 +323,13 @@ public class PathCompilerTest {
     public void property_must_be_separated_by_commas() {
         compile("$['aaa'}'bbb']");
     }
+
+    @Test
+    // https://github.com/jayway/JsonPath/issues/677
+    public void scientificNotationTest(){
+        String asbsad="{ \"Product\": \"LAMOTRIGINE\", \"nrx_quantity\": 5.41422482E8, \"nrx_quantity_pct\": 100 }";
+        List<String> result = JsonPath.read(asbsad, "$..*");
+        Assert.assertEquals(result.get(1),5.41422482E8);
+        Assertions.assertThat(result.toString()).isEqualTo("[\"LAMOTRIGINE\",5.41422482E8,100]");
+    }
 }


### PR DESCRIPTION
The test case in FilterTest.java is for issue #692 . The problem is caused by part of the parse tree around Line 129~164 in FilterCompiler.java. I created this test case for some auto-fix tools such as astor and prapr and for further research into the problem.

The test case in PathCompilerTest.java is for issue #677 . The problem might be caused by confronting toPlainString() and toString() dealing with exponent and is verified to be solved in JsonPath with correct calls of functions.