### PR TITLE
Fix issue #680 and two testcase

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -254,4 +254,14 @@ public class Configuration {
         MappingProvider mappingProvider();
 
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Configuration that = (Configuration) o;
+        return jsonProvider.getClass() == that.jsonProvider.getClass() &&
+                mappingProvider.getClass() == that.mappingProvider.getClass() &&
+                Objects.equals(options, that.options);
+    }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/Parameter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/Parameter.java
@@ -70,6 +70,10 @@ public class Parameter {
         this.json = json;
     }
 
+    public ILateBindingValue getILateBingValue(){
+        return lateBinding;
+    }
+
     /**
      * Translate the collection of parameters into a collection of values of type T.
      *

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -17,6 +17,8 @@ package com.jayway.jsonpath.internal.function.latebinding;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.internal.Path;
 
+import java.util.Objects;
+
 /**
  * Defines the contract for late bindings, provides document state and enough context to perform the evaluation at a later
  * date such that we can operate on a dynamically changing value.
@@ -28,19 +30,32 @@ public class PathLateBindingValue implements ILateBindingValue {
     private final Path path;
     private final Object rootDocument;
     private final Configuration configuration;
-
+    private Object result;
     public PathLateBindingValue(final Path path, final Object rootDocument, final Configuration configuration) {
         this.path = path;
         this.rootDocument = rootDocument;
         this.configuration = configuration;
+        result = null;
     }
 
     /**
-     * Evaluate the expression at the point of need for Path type expressions
      *
      * @return the late value
      */
     public Object get() {
-        return path.evaluate(rootDocument, rootDocument, configuration).getValue();
+        if(result==null) {
+            this.result = path.evaluate(rootDocument, rootDocument, configuration).getValue();
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PathLateBindingValue that = (PathLateBindingValue) o;
+        return Objects.equals(path, that.path) &&
+                Objects.equals(rootDocument, that.rootDocument) &&
+                Objects.equals(configuration, that.configuration);
     }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -28,12 +28,14 @@ import java.util.Objects;
  */
 public class PathLateBindingValue implements ILateBindingValue {
     private final Path path;
-    private final Object rootDocument;
+    private final String rootDocument;
     private final Configuration configuration;
+    private final Object result;
     public PathLateBindingValue(final Path path, final Object rootDocument, final Configuration configuration) {
         this.path = path;
-        this.rootDocument = rootDocument;
+        this.rootDocument = rootDocument.toString();
         this.configuration = configuration;
+        this.result = path.evaluate(rootDocument, rootDocument, configuration).getValue();
     }
 
     /**
@@ -41,7 +43,7 @@ public class PathLateBindingValue implements ILateBindingValue {
      * @return the late value
      */
     public Object get() {
-        return path.evaluate(rootDocument, rootDocument, configuration).getValue();
+        return result;
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -30,12 +30,10 @@ public class PathLateBindingValue implements ILateBindingValue {
     private final Path path;
     private final Object rootDocument;
     private final Configuration configuration;
-    private Object result;
     public PathLateBindingValue(final Path path, final Object rootDocument, final Configuration configuration) {
         this.path = path;
         this.rootDocument = rootDocument;
         this.configuration = configuration;
-        result = null;
     }
 
     /**
@@ -43,10 +41,7 @@ public class PathLateBindingValue implements ILateBindingValue {
      * @return the late value
      */
     public Object get() {
-        if(result==null) {
-            this.result = path.evaluate(rootDocument, rootDocument, configuration).getValue();
-        }
-        return result;
+        return path.evaluate(rootDocument, rootDocument, configuration).getValue();
     }
 
     @Override
@@ -55,7 +50,7 @@ public class PathLateBindingValue implements ILateBindingValue {
         if (o == null || getClass() != o.getClass()) return false;
         PathLateBindingValue that = (PathLateBindingValue) o;
         return Objects.equals(path, that.path) &&
-                Objects.equals(rootDocument, that.rootDocument) &&
+                rootDocument.equals(that.rootDocument) &&
                 Objects.equals(configuration, that.configuration);
     }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/FunctionPathToken.java
@@ -48,17 +48,20 @@ public class FunctionPathToken extends PathToken {
 
         if (null != functionParams) {
             for (Parameter param : functionParams) {
-                if (!param.hasEvaluated()) {
-                    switch (param.getType()) {
-                        case PATH:
-                            param.setLateBinding(new PathLateBindingValue(param.getPath(), ctx.rootDocument(), ctx.configuration()));
+                switch (param.getType()) {
+                    case PATH:
+                        PathLateBindingValue pathLateBindingValue = new PathLateBindingValue(param.getPath(), ctx.rootDocument(), ctx.configuration());
+                        if (!param.hasEvaluated()||!pathLateBindingValue.equals(param.getILateBingValue())) {
+                            param.setLateBinding(pathLateBindingValue);
                             param.setEvaluated(true);
-                            break;
-                        case JSON:
+                        }
+                        break;
+                    case JSON:
+                        if (!param.hasEvaluated()) {
                             param.setLateBinding(new JsonLateBindingValue(ctx.configuration().jsonProvider(), param));
                             param.setEvaluated(true);
-                            break;
-                    }
+                        }
+                        break;
                 }
             }
         }

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
@@ -1,0 +1,32 @@
+package com.jayway.jsonpath.internal.function;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue680 {
+
+    @Test
+    public void testIssue680concat() {
+        String json = "{ \"key\": \"first\"}";
+        Object value = JsonPath.read(json, "concat(\"/\", $.key, $.key)");
+        assertThat(value).isEqualTo("/first");
+        json = "{ \"key\": \"second\"}";
+        value = JsonPath.read(json, "concat(\"/\", $.key, $.key)");
+        assertThat(value).isEqualTo("/second");
+    }
+
+    @Test
+    public void testIssue680min() {
+        String json = "{ \"key\": 1}";
+        double value = JsonPath.read(json, "min($.key)");
+        assertThat(value).isEqualTo(1d);
+        json = "{ \"key\": 2}";
+        value = JsonPath.read(json, "min($.key)");
+        assertThat(value).isEqualTo(2d);
+    }
+}

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
@@ -16,10 +16,10 @@ public class Issue680 {
     @Test
     public void testIssue680concat() {
         String json = "{ \"key\": \"first\"}";
-        Object value = JsonPath.read(json, "concat(\"/\", $.key, $.key)");
+        Object value = JsonPath.read(json, "concat(\"/\", $.key)");
         assertThat(value).isEqualTo("/first");
         json = "{ \"key\": \"second\"}";
-        value = JsonPath.read(json, "concat(\"/\", $.key, $.key)");
+        value = JsonPath.read(json, "concat(\"/\", $.key)");
         assertThat(value).isEqualTo("/second");
     }
 

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
@@ -35,11 +35,11 @@ public class Issue680 {
 
     @Test
     public void testIssue680concat_2() {
-        Map<String, String> context = new HashMap<>();
+        Map<String, String> context = new HashMap<String, String>();
         context.put("key", "first");
         Object value = JsonPath.read(context, "concat(\"/\", $.key)");
         assertThat(value).isEqualTo("/first");
-        Map<String, String> context2 = new HashMap<>();
+        Map<String, String> context2 = new HashMap<String, String>();
         context2.put("key", "second");
         value = JsonPath.read(context2, "concat(\"/\", $.key)");
         assertThat(value).isEqualTo("/second");

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue680.java
@@ -6,6 +6,9 @@ import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Issue680 {
@@ -28,5 +31,17 @@ public class Issue680 {
         json = "{ \"key\": 2}";
         value = JsonPath.read(json, "min($.key)");
         assertThat(value).isEqualTo(2d);
+    }
+
+    @Test
+    public void testIssue680concat_2() {
+        Map<String, String> context = new HashMap<>();
+        context.put("key", "first");
+        Object value = JsonPath.read(context, "concat(\"/\", $.key)");
+        assertThat(value).isEqualTo("/first");
+        Map<String, String> context2 = new HashMap<>();
+        context2.put("key", "second");
+        value = JsonPath.read(context2, "concat(\"/\", $.key)");
+        assertThat(value).isEqualTo("/second");
     }
 }


### PR DESCRIPTION
Fix issue #680 The cache only only caches the path corresponding to the result. So when another jsonObject is read, it will parse the original path using original jsonObject. I introduction a mechanism that when the jsonObject changes, it will change the cache.