### PR TITLE
fixed issue #537 (renameKey) and added tests

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -308,7 +308,17 @@ public class JsonPath {
         notNull(configuration, "configuration can not be null");
         EvaluationContext evaluationContext = path.evaluate(jsonObject, jsonObject, configuration, true);
         for (PathRef updateOperation : evaluationContext.updateOperations()) {
-            updateOperation.renameKey(oldKeyName, newKeyName, configuration);
+            boolean optSuppressExceptions = configuration.containsOption(Option.SUPPRESS_EXCEPTIONS);
+            try {
+                updateOperation.renameKey(oldKeyName, newKeyName, configuration);
+            } catch (RuntimeException e) {
+                if(!optSuppressExceptions){
+                    throw e;
+                }else{
+                    // With option SUPPRESS_EXCEPTIONS,
+                    // the PathNotFoundException should be ignored and the other updateOperation should be continued.
+                }
+            }
         }
         return resultByConfiguration(jsonObject, configuration, evaluationContext);
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_537.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_537.java
@@ -1,0 +1,29 @@
+package com.jayway.jsonpath;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class Issue_537 {
+
+    public static final Configuration jsonConf = Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS);
+
+    @Test
+    public void test_read(){  // originally passed
+        Object ans = JsonPath.using(jsonConf).parse("{}").read("missing");
+        assert(ans == null);
+    }
+
+    @Test
+    public void test_renameKey(){  // originally throws PathNotFoundException
+        List<Object> ans = JsonPath.using(jsonConf)
+                .parse("{\"list\":[" +
+                        "{\"data\":{\"old\":1}}," +
+                        "{\"data\":{}}," +
+                        "{\"data\":{\"old\":2}}" +
+                        "]}")
+                .renameKey("$..data", "old", "new")
+                .read("$.list");
+        assert(ans.toString().equals("[{\"data\":{\"new\":1}},{\"data\":{}},{\"data\":{\"new\":2}}]"));
+    }
+}


### PR DESCRIPTION
Issue #537 mentioned that, `renameKey` does not obey `SUPPRESS_EXCEPTIONS` option.

In this commit, when renaming a key with option `SUPPRESS_EXCEPTIONS`, the array elements which do not have such key should be ignored silently (rather than throwing `PathNotFoundException`), and the other elements having such key will be modified successfully.