### PR TITLE
fix issue_590 and add testcases

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/CharacterIndex.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/CharacterIndex.java
@@ -15,6 +15,10 @@ public class CharacterIndex {
     private static final char PERIOD = '.';
     private static final char REGEX = '/';
 
+    //workaround for issue: https://github.com/json-path/JsonPath/issues/590
+    private static final char SCI_E = 'E';
+    private static final char SCI_e = 'e';
+
     private final CharSequence charSequence;
     private int position;
     private int endPosition;
@@ -293,7 +297,8 @@ public class CharacterIndex {
 
     public boolean isNumberCharacter(int readPosition) {
         char c = charAt(readPosition);
-        return Character.isDigit(c) || c == MINUS  || c == PERIOD;
+        //workaround for issue: https://github.com/json-path/JsonPath/issues/590
+        return Character.isDigit(c) || c == MINUS  || c == PERIOD || c == SCI_E || c == SCI_e;
     }
 
     public CharacterIndex skipBlanks() {

--- a/json-path/src/test/java/com/jayway/jsonpath/ScientificNotationTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/ScientificNotationTest.java
@@ -1,0 +1,47 @@
+package com.jayway.jsonpath;
+
+import com.google.gson.JsonArray;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.jayway.jsonpath.JsonPath.using;
+import static org.assertj.core.api.Assertions.assertThat;
+
+//test for issue: https://github.com/json-path/JsonPath/issues/590
+public class ScientificNotationTest extends BaseTest {
+
+    final String sci_rep_array = "{\"num_array\": [" +
+            "{\"num\":1}," +
+            "{\"num\":-1e-10}," +
+            "{\"num\":0.1e10},"+
+            "{\"num\":2E-20}," +
+            "{\"num\":-0.2E20}" +
+            " ]}";
+
+    @Test
+    public void testScientificNotation() {
+        List<JsonArray> result = using(Configuration.defaultConfiguration())
+                .parse(sci_rep_array)
+                .read("$.num_array[?(@.num == 1 || @.num == -1e-10 || @.num == 0.1e10 || @.num == 2E-20 || @.num == -0.2E20)]");
+
+        assertThat(result.toString()).isEqualTo("[{\"num\":1},{\"num\":-1.0E-10},{\"num\":1.0E9},{\"num\":2.0E-20},{\"num\":-2.0E19}]");
+    }
+    @Test
+    public void testScientificNotation_lt_gt() {
+        List<JsonArray> result;
+        result = using(Configuration.defaultConfiguration())
+                .parse(sci_rep_array)
+                .read("$.num_array[?(@.num > -0.0E0)]");
+
+        assertThat(result.toString()).isEqualTo("[{\"num\":1},{\"num\":1.0E9},{\"num\":2.0E-20}]");
+
+        result = using(Configuration.defaultConfiguration())
+                .parse(sci_rep_array)
+                .read("$.num_array[?(@.num < -0.0E0)]");
+
+        assertThat(result.toString()).isEqualTo("[{\"num\":-1.0E-10},{\"num\":-2.0E19}]");
+
+    }
+
+}


### PR DESCRIPTION
fix issue [#590](https://github.com/json-path/JsonPath/issues/590) and add testcases.

The issue mainly disscuss that if there exist exponents in the path like `@.num == -0.2E20`. It will throw like:

```
com.jayway.jsonpath.InvalidPathException: Expected character: )
```

And the commit is to support this Scientific Notation formate in the 'path'.