### PR TITLE
Support convert normal object as parsed json tree

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/ParseContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/ParseContextImpl.java
@@ -28,7 +28,8 @@ public class ParseContextImpl implements ParseContext {
     @Override
     public DocumentContext parse(Object json) {
         notNull(json, "json object can not be null");
-        return new JsonContext(json, configuration);
+        Object obj = configuration.jsonProvider().parse(json);
+        return new JsonContext(obj, configuration);
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
@@ -120,6 +120,11 @@ public class GsonJsonProvider extends AbstractJsonProvider {
     }
 
     @Override
+    public Object parse(Object object) throws InvalidJsonException {
+        return object instanceof JsonElement ? object : gson.toJsonTree(object);
+    }
+
+    @Override
     public Object parse(final String json) throws InvalidJsonException {
         return PARSER.parse(json);
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
@@ -46,6 +46,11 @@ public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
     }
 
     @Override
+    public Object parse(Object object) throws InvalidJsonException {
+        return object instanceof JsonNode ? object : objectMapper.valueToTree(object);
+    }
+
+    @Override
     public Object parse(String json) throws InvalidJsonException {
         try {
             return objectMapper.readTree(json);

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonProvider.java
@@ -24,6 +24,16 @@ public interface JsonProvider {
     static final Object UNDEFINED = new Object();
 
     /**
+     * Convert the given object as a parsed json object
+     * @param object object to parse
+     * @return The parsed json object
+     * @throws InvalidJsonException
+     */
+    default Object parse(Object object) throws InvalidJsonException {
+        return object;
+    }
+
+    /**
      * Parse the given json string
      * @param json json string to parse
      * @return Object representation of json

--- a/json-path/src/test/java/com/jayway/jsonpath/GsonJsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/GsonJsonProviderTest.java
@@ -1,8 +1,11 @@
 package com.jayway.jsonpath;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.jayway.jsonpath.JacksonJsonNodeJsonProviderTest.FooBarBaz;
+import com.jayway.jsonpath.JacksonJsonNodeJsonProviderTest.Gen;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingException;
@@ -205,6 +208,25 @@ public class GsonJsonProviderTest extends BaseTest {
       assertThat(result).isNull();
     }
 
+    @Test
+    public void object_can_be_parsed() {
+        Gen gen = new Gen();
+        gen.eric = "yepp";
+
+        FooBarBaz<Gen> fooBarBaz = new FooBarBaz<>();
+        fooBarBaz.foo = "foo0";
+        fooBarBaz.bar = 0L;
+        fooBarBaz.baz = true;
+        fooBarBaz.gen = gen;
+
+        DocumentContext context = using(GSON_CONFIGURATION).parse(fooBarBaz);
+        assertThat((Object) context.json()).isInstanceOf(JsonElement.class);
+
+        assertThat(context.read("$.foo", String.class)).isEqualTo("foo0");
+        assertThat(context.read("$.bar", Long.class)).isZero();
+        assertThat(context.read("$.baz", Boolean.class)).isTrue();
+        assertThat(context.read("$.gen.eric", String.class)).isEqualTo("yepp");
+    }
 
     public static class FooBarBaz<T> {
         public T gen;

--- a/json-path/src/test/java/com/jayway/jsonpath/JacksonJsonNodeJsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JacksonJsonNodeJsonProviderTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.jayway.jsonpath.internal.JsonContext;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingException;
@@ -245,6 +246,26 @@ public class JacksonJsonNodeJsonProviderTest extends BaseTest {
       ArrayNode node = using(JACKSON_JSON_NODE_CONFIGURATION).parse(json).read("$[?(@.groups[?(@.type == 'phase' && @.name == 'alpha')] empty false)]");
       assertThat(node.size()).isEqualTo(1);
       assertThat(node.get(0).get("name").asText()).isEqualTo("a");
+    }
+
+    @Test
+    public void object_can_be_parsed() {
+        Gen gen = new Gen();
+        gen.eric = "yepp";
+
+        FooBarBaz<Gen> fooBarBaz = new FooBarBaz<>();
+        fooBarBaz.foo = "foo0";
+        fooBarBaz.bar = 0L;
+        fooBarBaz.baz = true;
+        fooBarBaz.gen = gen;
+
+        DocumentContext context = using(JACKSON_JSON_NODE_CONFIGURATION).parse(fooBarBaz);
+        assertThat((Object) context.json()).isInstanceOf(JsonNode.class);
+
+        assertThat(context.read("$.foo", String.class)).isEqualTo("foo0");
+        assertThat(context.read("$.bar", Long.class)).isZero();
+        assertThat(context.read("$.baz", Boolean.class)).isTrue();
+        assertThat(context.read("$.gen.eric", String.class)).isEqualTo("yepp");
     }
 
     public static class FooBarBaz<T> {


### PR DESCRIPTION
Both GSON and Jackson can convert a normal java object as a JSON tree. So it can run the JsonPath query on almost every object.
I add a method `parse(Object object)` to JsonProvider to support this. I mark this method as `default`, so it should not impact any third-party implementation of `JsonProvider`.