### PR TITLE
Replace JCenter repo for Maven Central and Gradle M2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.1.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 

--- a/gradle/binaryCompatibility.gradle
+++ b/gradle/binaryCompatibility.gradle
@@ -21,7 +21,10 @@ import groovy.text.markup.TemplateConfiguration
 buildscript {
     // this block should not be necessary, but for some reason it fails without!
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {


### PR DESCRIPTION
This is a pull request to resolve the issue #728 