### PR TITLE
Replace Gradle OSGi plugin for BND build tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.1.0'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
+        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0'
     }
 }
 
@@ -50,7 +51,7 @@ allprojects {
 subprojects {
     apply plugin: 'java'
     apply plugin: 'signing'
-    apply plugin: 'osgi'
+    apply plugin: 'biz.aQute.bnd.builder'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.1.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 

--- a/gradle/binaryCompatibility.gradle
+++ b/gradle/binaryCompatibility.gradle
@@ -21,7 +21,10 @@ import groovy.text.markup.TemplateConfiguration
 buildscript {
     // this block should not be necessary, but for some reason it fails without!
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {

--- a/json-path-assert/build.gradle
+++ b/json-path-assert/build.gradle
@@ -4,9 +4,9 @@ description = "Assertions on Json using JsonPath"
 
 jar {
     baseName 'json-path-assert'
-    manifest {
-        attributes 'Implementation-Title': 'json-path-assert', 'Implementation-Version': version
-    }
+    bnd (
+        'Implementation-Title': 'json-path-assert', 'Implementation-Version': version
+    )
 }
 
 dependencies {

--- a/json-path-web-test/build.gradle
+++ b/json-path-web-test/build.gradle
@@ -18,11 +18,11 @@ task createBuildInfoFile {
 jar {
     dependsOn createBuildInfoFile
     baseName 'json-path-web-test'
-    manifest {
-        attributes 'Implementation-Title': 'json-path-web-test',
-                   'Implementation-Version': version,
-                   'Main-Class': mainClassName
-    }
+    bnd (
+        'Implementation-Title': 'json-path-web-test',
+        'Implementation-Version': version,
+        'Main-Class': mainClassName
+    )
 }
 
 

--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -4,10 +4,10 @@ description = "Java port of Stefan Goessner JsonPath."
 
 jar {
     baseName 'json-path'
-    manifest {
-        attributes 'Implementation-Title': 'json-path', 'Implementation-Version': version
-        instruction 'Import-Package', 'org.json.*;resolution:=optional', 'com.google.gson.*;resolution:=optional', 'com.fasterxml.jackson.*;resolution:=optional', 'org.apache.tapestry5.json.*;resolution:=optional', 'org.codehaus.jettison.*;resolution:=optional', '*'
-    }
+    bnd (
+        'Implementation-Title': 'json-path', 'Implementation-Version': version,
+        'Import-Package': 'org.json.*;resolution:=optional, com.google.gson.*;resolution:=optional, com.fasterxml.jackson.*;resolution:=optional, org.apache.tapestry5.json.*;resolution:=optional, org.codehaus.jettison.*;resolution:=optional, *'
+    )
 }
 
 dependencies {


### PR DESCRIPTION
Ref #727 

The OSGi plugin for Gradle has been officially deprecated since Gradle 5.0 is out, and will be probably removed in the coming year or so. Gradle site says:

> New builds should not use this plugin. A separate plugin implementation is maintained by the BND authors that has more advanced features.

Source: https://docs.gradle.org/5.0/userguide/osgi_plugin.html