### PR TITLE
Fix concat with text and number

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/Parameter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/Parameter.java
@@ -129,6 +129,8 @@ public class Parameter {
         } else {
             if (value != null && expectedType.isAssignableFrom(value.getClass())) {
                 collection.add(value);
+            } else if (value != null && expectedType == String.class) {
+                collection.add(value.toString());
             }
         }
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/BaseFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/BaseFunctionTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BaseFunctionTest {
     protected static final String NUMBER_SERIES = "{\"empty\": [], \"numbers\" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}";
     protected static final String TEXT_SERIES = "{\"urls\": [\"http://api.worldbank.org/countries/all/?format=json\", \"http://api.worldbank.org/countries/all/?format=json\"], \"text\" : [ \"a\", \"b\", \"c\", \"d\", \"e\", \"f\" ]}";
+    protected static final String TEXT_AND_NUMBER_SERIES = "{\"text\" : [ \"a\", \"b\", \"c\", \"d\", \"e\", \"f\" ], \"numbers\" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}";
 
     /**
      * Verify the function returns the correct result based on the input expectedValue
@@ -38,6 +39,10 @@ public class BaseFunctionTest {
 
     protected void verifyTextFunction(Configuration conf, String pathExpr, Object expectedValue) {
         verifyFunction(conf, pathExpr, TEXT_SERIES, expectedValue);
+    }
+
+    protected void verifyTextAndNumberFunction(Configuration conf, String pathExpr, Object expectedValue) {
+        verifyFunction(conf, pathExpr, TEXT_AND_NUMBER_SERIES, expectedValue);
     }
 
     protected String getResourceAsText(String resourceName) throws IOException {

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
@@ -70,6 +70,11 @@ public class NestedFunctionTest extends BaseFunctionTest {
     }
 
     @Test
+    public void testStringAndNumberConcat() {
+        verifyTextAndNumberFunction(conf, "$.concat($.text[0], $.numbers[0])", "a1");
+    }
+
+    @Test
     public void testStringConcatWithJSONParameter() {
         verifyTextFunction(conf, "$.text.concat(\"-\", \"ghijk\")", "abcdef-ghijk");
     }


### PR DESCRIPTION
Currently concat function is not working for text and numbers. When a number parameter is consumed and expected to be a string it is ignored.