### PR TITLE
Fix issues 400, 482, 487: Allow comma in the quoted string

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -612,7 +612,7 @@ public class PathCompiler {
                     inProperty = true;
                     lastSignificantWasComma = false;
                 }
-            } else if (c == COMMA){
+            } else if (c == COMMA && !inProperty) {
                 if (lastSignificantWasComma){
                     fail("Found empty property at index "+readPosition);
                 }

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_487.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_487.java
@@ -1,0 +1,26 @@
+package com.jayway.jsonpath;
+
+import org.junit.Test;
+
+public class Issue_487 {
+
+    public static final Configuration jsonConf = Configuration.defaultConfiguration();
+
+    @Test//(expected = InvalidPathException.class)
+    public void test_read_with_comma_1(){  // originally throws InvalidPathException
+        DocumentContext dc = JsonPath.using(jsonConf)
+                .parse("{ \"key,\" : \"value\" }");
+        Object ans = dc.read(JsonPath.compile("$['key,']"));
+        //System.out.println(ans);
+        assert(ans.toString().equals("value"));
+    }
+
+    @Test
+    public void test_read_with_comma_2(){  // originally passed
+        DocumentContext dc = JsonPath.using(jsonConf)
+                .parse("{ \"key,\" : \"value\" }");
+        Object ans = dc.read(JsonPath.compile("$['key\\,']"));
+        //System.out.println(ans);
+        assert(ans.toString().equals("value"));
+    }
+}


### PR DESCRIPTION
So far the issue #400 was closed by repo maintainer without any reasoning. The issue #482 was closed with a recommended workaround (escape commas within quoted parts of JsonPath), and issue #487 is still open. They all share the same underlying cause - a simple comma character, say, within the quoted property (quoted string) causes ``PathCompiler`` to throw up an exception, as it believes EVERY comma is a separator between properties or array indices. But it is so only when a comma lives outside the property or index; inside the quoted string, everything is possible, generally speaking.

This is a one-liner fix to the ``PathCompiler`` tokenization logic that allows it to skip quoted commas, and few unit tests to confirm it.