### PR TITLE
Cache access tweaks

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -29,13 +29,12 @@ import com.jayway.jsonpath.spi.cache.CacheProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedList;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.jayway.jsonpath.JsonPath.compile;
 import static com.jayway.jsonpath.internal.Utils.notEmpty;
 import static com.jayway.jsonpath.internal.Utils.notNull;
-import static java.util.Arrays.asList;
 
 public class JsonContext implements DocumentContext {
 
@@ -216,7 +215,8 @@ public class JsonContext implements DocumentContext {
 
     private JsonPath pathFromCache(String path, Predicate[] filters) {
         Cache cache = CacheProvider.getCache();
-        String cacheKey = Utils.concat(path, new LinkedList<Predicate>(asList(filters)).toString());
+        String cacheKey = filters == null || filters.length == 0
+            ? path : Utils.concat(path, Arrays.toString(filters));
         JsonPath jsonPath = cache.get(cacheKey);
         if (jsonPath == null) {
             jsonPath = compile(path, filters);

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/cache/CacheProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/cache/CacheProvider.java
@@ -2,31 +2,47 @@ package com.jayway.jsonpath.spi.cache;
 
 import com.jayway.jsonpath.JsonPathException;
 
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
 import static com.jayway.jsonpath.internal.Utils.notNull;
 
 public class CacheProvider {
-    private static Cache cache;
+
+    private static final AtomicReferenceFieldUpdater<CacheProvider, Cache> UPDATER =
+        AtomicReferenceFieldUpdater.newUpdater(CacheProvider.class, Cache.class, "cache");
+    private static final CacheProvider instance = new CacheProvider();
+
+    private volatile Cache cache;
+
+    private static class CacheHolder {
+        static final Cache CACHE;
+        static {
+            Cache cache = CacheProvider.instance.cache;
+            // the application is trying to use the cache
+            // and if no external implementation has been registered,
+            // we need to initialise it to the default LRUCache
+            if (cache == null) {
+                cache = getDefaultCache();
+                // on the off chance that the cache implementation was registered during
+                // initialisation of the holder, this should be respected, so if the
+                // default cache can't be written back, just read the user supplied value again
+                if (!UPDATER.compareAndSet(instance, null, cache)) {
+                    cache = CacheProvider.instance.cache;
+                }
+            }
+            CACHE = cache;
+        }
+    }
 
     public static void setCache(Cache cache){
         notNull(cache, "Cache may not be null");
-        synchronized (CacheProvider.class){
-            if(CacheProvider.cache != null){
-                throw new JsonPathException("Cache provider must be configured before cache is accessed.");
-            } else {
-                CacheProvider.cache = cache;
-            }
+        if (!UPDATER.compareAndSet(instance, null, cache)) {
+            throw new JsonPathException("Cache provider must be configured before cache is accessed and must not be registered twice.");
         }
     }
 
     public static Cache getCache() {
-        if(CacheProvider.cache == null){
-            synchronized (CacheProvider.class){
-                if(CacheProvider.cache == null){
-                    CacheProvider.cache = getDefaultCache();
-                }
-            }
-        }
-        return CacheProvider.cache;
+        return CacheHolder.CACHE;
     }
 
 


### PR DESCRIPTION
This includes two changes

1. a new cache key isn't created for each cached `JsonPath` lookup if there aren't any filters.
2. I noticed the cache SPI uses double checked locking on a non volatile field, which the compiler is allowed to reorder so the idiom doesn't work. I replaced this with a variant of the [singleton holder pattern](https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom) which writes the `cache` instance back to the `CacheProvider` to ensure SPI users get to set the cache or get an exception because the cache implementation was already registered.