### PR TITLE
Don't fill in stack trace in PathNotFoundException

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/PathNotFoundException.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/PathNotFoundException.java
@@ -30,4 +30,9 @@ public class PathNotFoundException extends InvalidPathException {
     public PathNotFoundException(Throwable cause) {
         super(cause);
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
 }


### PR DESCRIPTION
This exception seems to be used for control flow, which leads to high CPU consumption. 

<img width="1424" alt="Screenshot 2021-09-08 at 17 58 30" src="https://user-images.githubusercontent.com/16439049/132576041-9295b026-1c51-4655-9a89-557b1d93b17a.png">

This change uses a standard trick to reduce the cost of exception based control flow to virtually nothing.