### PR TITLE
prevent truncated subexpressions + misc code cleanup

### DIFF
--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue629.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/Issue629.java
@@ -6,13 +6,15 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 
 public class Issue629 {
     @Test
     public void testUncloseParenthesis() throws IOException {
         try {
             JsonPath jsonPath = JsonPath.compile("$.A.B.C.D(");
-            assert(false);
+            fail("accepted jsonpath with unclosed parentheses");
         }
         catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Arguments to function:"));
@@ -23,7 +25,7 @@ public class Issue629 {
     public void testUncloseParenthesisWithNestedCall() throws IOException {
         try {
             JsonPath jsonPath = JsonPath.compile("$.A.B.C.sum(D()");
-            assert(false);
+            fail("accepted jsonpath with unclosed parentheses");
         }
         catch (Exception e) {
             assertTrue(e.getMessage().startsWith("Arguments to function:"));


### PR DESCRIPTION
This includes a fix for #693 which led to violations of the check for imbalanced parentheses introduced in #698 whenever a function has no arguments. This is the underlying cause of the test failures on master.

cc @kallestenflo @davsclaus 