### PR TITLE
respect `SUPPRESS_EXCEPTIONS` configuration

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
@@ -48,6 +48,7 @@ public class EvaluationContextImpl implements EvaluationContext {
     private final List<PathRef> updateOperations;
     private final HashMap<Path, Object> documentEvalCache = new HashMap<Path, Object>();
     private final boolean forUpdate;
+    private final boolean suppressExceptions;
     private int resultIndex = 0;
 
 
@@ -61,7 +62,8 @@ public class EvaluationContextImpl implements EvaluationContext {
         this.configuration = configuration;
         this.valueResult = configuration.jsonProvider().createArray();
         this.pathResult = configuration.jsonProvider().createArray();
-        this.updateOperations = new ArrayList<PathRef>();
+        this.updateOperations = new ArrayList<>();
+        this.suppressExceptions = configuration.containsOption(Option.SUPPRESS_EXCEPTIONS);
     }
 
     public HashMap<Path, Object> documentEvalCache() {
@@ -129,7 +131,10 @@ public class EvaluationContextImpl implements EvaluationContext {
     @Override
     public <T> T getValue(boolean unwrap) {
         if (path.isDefinite()) {
-            if(resultIndex == 0){
+            if(resultIndex == 0) {
+                if (suppressExceptions) {
+                    return null;
+                }
                 throw new PathNotFoundException("No results for path: " + path.toString());
             }
             int len = jsonProvider().length(valueResult);
@@ -145,7 +150,10 @@ public class EvaluationContextImpl implements EvaluationContext {
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getPath() {
-        if(resultIndex == 0){
+        if(resultIndex == 0) {
+            if (suppressExceptions) {
+                return null;
+            }
             throw new PathNotFoundException("No results for path: " + path.toString());
         }
         return (T)pathResult;

--- a/json-path/src/test/java/com/jayway/jsonpath/TestSuppressExceptions.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/TestSuppressExceptions.java
@@ -1,0 +1,31 @@
+package com.jayway.jsonpath;
+
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+
+public class TestSuppressExceptions {
+
+  @Test
+  public void testSuppressExceptionsIsRespected() {
+    ParseContext parseContext = JsonPath.using(
+        new Configuration.ConfigurationBuilder().jsonProvider(new JacksonJsonProvider())
+            .mappingProvider(new JacksonMappingProvider()).options(Option.SUPPRESS_EXCEPTIONS)
+            .build());
+    String json = "{}";
+    assertNull(parseContext.parse(json).read(JsonPath.compile("$.missing")));
+  }
+
+  @Test
+  public void testSuppressExceptionsIsRespectedPath() {
+    ParseContext parseContext = JsonPath.using(
+        new Configuration.ConfigurationBuilder().jsonProvider(new JacksonJsonProvider())
+            .mappingProvider(new JacksonMappingProvider()).options(Option.SUPPRESS_EXCEPTIONS, Option.AS_PATH_LIST)
+            .build());
+    String json = "{}";
+    assertNull(parseContext.parse(json).read(JsonPath.compile("$.missing")));
+  }
+}


### PR DESCRIPTION
Even when using the `SUPPRESS_EXCEPTIONS` configuration option, `PathNotFoundExceptions` are thrown when paths don't match the JSON. Since #751 hasn't been released yet this has a significant performance impact.