### PR TITLE
expose JSON providers ability to parse UTF-8 byte arrays

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/ParseContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/ParseContext.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+
 /**
  * Parses JSON as specified by the used {@link com.jayway.jsonpath.spi.json.JsonProvider}.
  */
@@ -33,6 +34,8 @@ public interface ParseContext {
     DocumentContext parse(InputStream json, String charset);
 
     DocumentContext parse(File json) throws IOException;
+
+    DocumentContext parseUtf8(byte[] json);
 
     @Deprecated
     DocumentContext parse(URL json) throws IOException;

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/ParseContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/ParseContextImpl.java
@@ -39,6 +39,13 @@ public class ParseContextImpl implements ParseContext {
     }
 
     @Override
+    public DocumentContext parseUtf8(byte[] json) {
+        notEmpty(json, "json bytes can not be null or empty");
+        Object obj = configuration.jsonProvider().parse(json);
+        return new JsonContext(obj, configuration);
+    }
+
+    @Override
     public DocumentContext parse(InputStream json) {
         return parse(json, "UTF-8");
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/Utils.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/Utils.java
@@ -410,6 +410,26 @@ public final class Utils {
      * <p/>
      * <pre>Validate.notEmpty(myString, "The string must not be empty");</pre>
      *
+     * @param bytes   the bytes to check, validated not null by this method
+     * @param message the {@link String#format(String, Object...)} exception message if invalid, not null
+     * @return the validated character sequence (never {@code null} method for chaining)
+     * @throws NullPointerException     if the character sequence is {@code null}
+     * @throws IllegalArgumentException if the character sequence is empty
+     */
+    public static byte[] notEmpty(byte[] bytes, String message) {
+        if (bytes == null || bytes.length == 0) {
+            throw new IllegalArgumentException(message);
+        }
+        return bytes;
+    }
+
+    /**
+     * <p>Validate that the specified argument character sequence is
+     * neither {@code null} nor a length of zero (no characters);
+     * otherwise throwing an exception with the specified message.
+     * <p/>
+     * <pre>Validate.notEmpty(myString, "The string must not be empty");</pre>
+     *
      * @param <T>     the character sequence type
      * @param chars   the character sequence to check, validated not null by this method
      * @param message the {@link String#format(String, Object...)} exception message if invalid, not null

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
@@ -8,16 +8,17 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+
 
 public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
 
@@ -51,6 +52,16 @@ public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
             return objectMapper.readTree(json);
         } catch (IOException e) {
             throw new InvalidJsonException(e, json);
+        }
+    }
+
+    @Override
+    public Object parse(byte[] json)
+        throws InvalidJsonException {
+        try {
+            return objectMapper.readTree(json);
+        } catch (IOException e) {
+            throw new InvalidJsonException(e, new String(json, StandardCharsets.UTF_8));
         }
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonProvider.java
@@ -18,14 +18,15 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.jayway.jsonpath.InvalidJsonException;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+
 
 public class JacksonJsonProvider extends AbstractJsonProvider {
 
@@ -70,6 +71,16 @@ public class JacksonJsonProvider extends AbstractJsonProvider {
             return objectReader.readValue(json);
         } catch (IOException e) {
             throw new InvalidJsonException(e, json);
+        }
+    }
+
+    @Override
+    public Object parse(byte[] json)
+        throws InvalidJsonException {
+        try {
+            return objectReader.readValue(json);
+        } catch (IOException e) {
+            throw new InvalidJsonException(e, new String(json, StandardCharsets.UTF_8));
         }
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonProvider.java
@@ -15,9 +15,10 @@
 package com.jayway.jsonpath.spi.json;
 
 import com.jayway.jsonpath.InvalidJsonException;
-
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+
 
 public interface JsonProvider {
 
@@ -31,6 +32,15 @@ public interface JsonProvider {
      */
     Object parse(String json) throws InvalidJsonException;
 
+    /**
+     * Parse the given json bytes in UTF-8 encoding
+     * @param json json bytes to parse
+     * @return Object representation of json
+     * @throws InvalidJsonException
+     */
+    default Object parse(byte[] json) throws InvalidJsonException {
+        return parse(new String(json, StandardCharsets.UTF_8));
+    }
     /**
      * Parse the given json string
      * @param jsonStream input stream to parse

--- a/json-path/src/test/java/com/jayway/jsonpath/JacksonJsonNodeJsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JacksonJsonNodeJsonProviderTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingException;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -50,6 +51,13 @@ public class JacksonJsonNodeJsonProviderTest extends BaseTest {
     @Test
     public void json_can_be_parsed() {
         ObjectNode node = using(JACKSON_JSON_NODE_CONFIGURATION).parse(JSON_DOCUMENT).read("$");
+        assertThat(node.get("string-property").asText()).isEqualTo("string-value");
+    }
+
+    @Test
+    public void bytes_json_can_be_parsed() {
+        ObjectNode node = using(JACKSON_JSON_NODE_CONFIGURATION).parseUtf8(JSON_DOCUMENT.getBytes(StandardCharsets.UTF_8))
+            .read("$");
         assertThat(node.get("string-property").asText()).isEqualTo("string-value");
     }
 

--- a/json-path/src/test/java/com/jayway/jsonpath/JacksonTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JacksonTest.java
@@ -1,11 +1,12 @@
 package com.jayway.jsonpath;
 
+import java.util.Date;
 import org.junit.Test;
 
-import java.util.Date;
-
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class JacksonTest extends BaseTest {
 
@@ -25,6 +26,12 @@ public class JacksonTest extends BaseTest {
         assertThat(fooBarBaz.bar).isEqualTo(10L);
         assertThat(fooBarBaz.baz).isEqualTo(true);
 
+        fooBarBaz = JsonPath.using(JACKSON_CONFIGURATION).parseUtf8(json.getBytes(UTF_8))
+            .read("$", FooBarBaz.class);
+
+        assertThat(fooBarBaz.foo).isEqualTo("foo");
+        assertThat(fooBarBaz.bar).isEqualTo(10L);
+        assertThat(fooBarBaz.baz).isEqualTo(true);
     }
 
     public static class FooBarBaz {
@@ -52,7 +59,11 @@ public class JacksonTest extends BaseTest {
         final Object readFromSingleQuote = JsonPath.using(JACKSON_CONFIGURATION).parse(jsonArray).read("$.[?(@.foo in ['bar'])].foo");
         final Object readFromDoubleQuote = JsonPath.using(JACKSON_CONFIGURATION).parse(jsonArray).read("$.[?(@.foo in [\"bar\"])].foo");
         assertThat(readFromSingleQuote).isEqualTo(readFromDoubleQuote);
-
+        final Object readFromSingleQuoteBytes = JsonPath.using(JACKSON_CONFIGURATION).parseUtf8(jsonArray.getBytes(UTF_8))
+            .read("$.[?(@.foo in ['bar'])].foo");
+        final Object readFromDoubleQuoteBytes = JsonPath.using(JACKSON_CONFIGURATION).parseUtf8(jsonArray.getBytes(UTF_8))
+            .read("$.[?(@.foo in [\"bar\"])].foo");
+        assertThat(readFromSingleQuoteBytes).isEqualTo(readFromDoubleQuoteBytes);
     }
 
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/JakartaJsonProviderTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/JakartaJsonProviderTest.java
@@ -1,19 +1,19 @@
 package com.jayway.jsonpath;
 
-import org.junit.Test;
-
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
-
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.Test;
 
 import static com.jayway.jsonpath.JsonPath.parse;
 import static com.jayway.jsonpath.JsonPath.using;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class JakartaJsonProviderTest extends BaseTest {
 
@@ -27,6 +27,15 @@ public class JakartaJsonProviderTest extends BaseTest {
 
 		assertThat(((JsonString) book.get("author")).getChars()).isEqualTo("Nigel Rees");
 	}
+
+  @Test
+  public void an_object_can_be_read_from_bytes() {
+    JsonObject book = using(JAKARTA_JSON_CONFIGURATION)
+        .parseUtf8(JSON_DOCUMENT.getBytes(UTF_8))
+        .read("$.store.book[0]");
+
+    assertThat(((JsonString) book.get("author")).getChars()).isEqualTo("Nigel Rees");
+  }
 
 	@Test
 	public void a_property_can_be_read() {


### PR DESCRIPTION
This allows the user to parse `byte[]` directly, so long as it's UTF-8. I defaulted to UTF-8 because Jackson does, and it doesn't accept a character encoding parameter when parsing from `byte[]`.