### PR TITLE
Fix possible StackOverflowError in Jakarta provider

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JakartaJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JakartaJsonProvider.java
@@ -817,17 +817,22 @@ public class JakartaJsonProvider extends AbstractJsonProvider {
 
 		@Override
 		public int hashCode() {
-			return arr.hashCode();
+			return arr != null ? arr.hashCode() : 0;
 		}
 
 		@Override
 	    public boolean equals(Object obj) {
+			if (obj == null) {
+				return this.arr == null;
+			} else if (obj instanceof JsonArrayProxy) {
+				return this.arr.equals(((JsonArrayProxy) obj).arr);
+			}
 			return arr.equals(obj);
 	    }
 
 		@Override
 	    public String toString() {
-			return arr.toString();
+			return arr != null ? arr.toString() : null;
 	    }
     }
 
@@ -1017,17 +1022,22 @@ public class JakartaJsonProvider extends AbstractJsonProvider {
 
 		@Override
 		public int hashCode() {
-			return obj.hashCode();
+			return obj != null ? obj.hashCode() : 0;
 		}
 
 		@Override
 	    public boolean equals(Object obj) {
-			return obj.equals(obj);
+			if (obj == null) {
+				return this.obj == null;
+			} else if (obj instanceof JsonObjectProxy) {
+				return this.obj.equals(((JsonObjectProxy) obj).obj);
+			}
+			return this.obj.equals(obj);
 	    }
 
 		@Override
 	    public String toString() {
-			return obj.toString();
+			return obj != null ? obj.toString() : null;
 	    }
     }
 }


### PR DESCRIPTION
While running JsonPath library with Jakarta (Java 8) JSON provider, I stumbled upon a rather nasty and obvious bug in the code I wrote myself half a year ago. The bug leads to running out of stack space i.e. omnious ``StackOverflowError`` when certain ``AbstractList`` default methods are invoked on ``JsonObject`` or ``JsonArray`` proxy wrappers. Not good at all, my bad.

The fix is trivial, though.