### PR TITLE
fix issue 777 and add two test cases

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
@@ -395,11 +395,19 @@ public class FilterCompiler  {
         if(filter.currentChar() != CLOSE_PARENTHESIS){
             return false;
         }
-        int idx = filter.indexOfPreviousSignificantChar();
-        if(idx == -1 || filter.charAt(idx) != OPEN_PARENTHESIS){
+        int idx = filter.position() - 1;
+        int closedParenthesisNumber = 1;
+        while (filter.inBounds(idx) && idx > lowerBound && closedParenthesisNumber > 0) {
+            if (filter.charAt(idx) == CLOSE_PARENTHESIS) {
+                closedParenthesisNumber++;
+            } else if (filter.charAt(idx) == OPEN_PARENTHESIS) {
+                closedParenthesisNumber--;
+            }
+            idx--;
+        }
+        if(!filter.inBounds(idx) || closedParenthesisNumber != 0){
             return false;
         }
-        idx--;
         while(filter.inBounds(idx) && idx > lowerBound){
             if(filter.charAt(idx) == PERIOD){
                 return true;

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_777.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_777.java
@@ -1,0 +1,59 @@
+package com.jayway.jsonpath;
+
+import org.junit.Test;
+
+public class Issue_777 {
+    public static final Configuration jsonConf = Configuration.defaultConfiguration();
+
+    @Test
+    public void test_01_nested_path_in_filter_value() {
+        String json = "{\n" +
+                "    \"store\": {\n" +
+                "        \"book\": [\n" +
+                "            {\n" +
+                "                \"category\": \"reference\",\n" +
+                "                \"author\": \"Nigel Rees\",\n" +
+                "                \"title\": \"Sayings of the Century\",\n" +
+                "                \"price\": 8.95\n" +
+                "            },\n" +
+                "            {\n" +
+                "                \"category\": \"fiction\",\n" +
+                "                \"author\": \"Evelyn Waugh\",\n" +
+                "                \"title\": \"Sword of Honour\",\n" +
+                "                \"price\": 12.99\n" +
+                "            },\n" +
+                "            {\n" +
+                "                \"category\": \"fiction\",\n" +
+                "                \"author\": \"Herman Melville\",\n" +
+                "                \"title\": \"Moby Dick\",\n" +
+                "                \"isbn\": \"0-553-21311-3\",\n" +
+                "                \"price\": 8.99\n" +
+                "            },\n" +
+                "            {\n" +
+                "                \"category\": \"fiction\",\n" +
+                "                \"author\": \"J. R. R. Tolkien\",\n" +
+                "                \"title\": \"The Lord of the Rings\",\n" +
+                "                \"isbn\": \"0-395-19395-8\",\n" +
+                "                \"price\": 22.99\n" +
+                "            }\n" +
+                "        ],\n" +
+                "        \"bicycle\": {\n" +
+                "            \"color\": \"red\",\n" +
+                "            \"price\": 19.95\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"expensive\": 10\n" +
+                "}";
+        DocumentContext dc = JsonPath.using(jsonConf).parse(json);
+        String result = dc.read("$.store.book[?(@.price == $.max($.store.book[*].price))].author").toString();
+        System.out.println(result);
+    }
+
+    @Test
+    public void test_02_nested_path_in_filter_value() {
+        String json = "{\"list\": [{\"val\": 1, \"name\": \"val=1\"}, {\"val\": 2, \"name\": \"val=2\"}, {\"val\": 3,\"name\": \"val=3\"}]}";
+        DocumentContext dc = JsonPath.using(jsonConf).parse(json);
+        String result = dc.read("$.list[?(@.val == $.max($.list[*].val))].name").toString();
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
This issue is a general problem . An error occurs when there are aggregate functions nested in the filter.

Reasons:
`private boolean currentCharIsClosingFunctionBracket(int lowerBound)` in  `com.jayway.jsonpath.internal.filter.FilterCompiler` is to determine that the current closed parenthesis is a function call bracket, however the original code implementation cannotsuccessfully judge this situation.