### PR TITLE
Upgrade jackson-databind dependency to resolve CVE issue.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     libs = [
             gson: 'com.google.code.gson:gson:2.8.9',
             hamcrest: 'org.hamcrest:hamcrest:2.2',
-            jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.13.1',
+            jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1',
             jettison: 'org.codehaus.jettison:jettison:1.4.1',
             jsonOrg: 'org.json:json:20140107',
             jsonSmart: 'net.minidev:json-smart:2.4.7',

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     libs = [
             gson: 'com.google.code.gson:gson:2.8.9',
             hamcrest: 'org.hamcrest:hamcrest:2.2',
-            jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1',
+            jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2',
             jettison: 'org.codehaus.jettison:jettison:1.4.1',
             jsonOrg: 'org.json:json:20140107',
             jsonSmart: 'net.minidev:json-smart:2.4.7',


### PR DESCRIPTION
JsonPath has a dependency to `com.fasterxml.jackson.core.jackson-databind` version `2.13.1` which has a reported and resolved vulnerability [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) ([GitHub advisory](https://github.com/advisories/GHSA-57j2-w4cx-62h2)) discussed in the issue https://github.com/FasterXML/jackson-databind/issues/2816. 

A version which resolves the issue has been released under version `2.13.2.2` (also included in `2.13.2.1` as the issue mentions.

This pull request simply updates the declared version in the `build.gradle` file to 2.13.2.2.