### PR TITLE
fix issue #744 and add test case

### DIFF
--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
@@ -5,6 +5,7 @@ import com.jayway.jsonassert.JsonAssert;
 import com.jayway.jsonassert.JsonAsserter;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.hamcrest.Matcher;
 
@@ -71,12 +72,9 @@ public class JsonAsserterImpl implements JsonAsserter {
     public JsonAsserter assertNotDefined(String path) {
 
         try {
-            Configuration c = Configuration.defaultConfiguration();
-
-            Object obj = JsonPath.using(c).parse(jsonObject).read(path);
-            if (!JsonAssert.emptyCollection().matches(obj)) {
-                throw new AssertionError(format("Document contains the path <%s> but was expected not to.", path));
-            }
+            Configuration c = Configuration.defaultConfiguration().addOptions(Option.REQUIRE_PROPERTIES);
+            JsonPath.using(c).parse(jsonObject).read(path);
+            throw new AssertionError(format("Document contains the path <%s> but was expected not to.", path));
         } catch (PathNotFoundException e) {
         }
         return this;
@@ -85,7 +83,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     @Override
     public JsonAsserter assertNotDefined(String path, String message) {
         try {
-            Configuration c = Configuration.defaultConfiguration();
+            Configuration c = Configuration.defaultConfiguration().addOptions(Option.REQUIRE_PROPERTIES);
 
             JsonPath.using(c).parse(jsonObject).read(path);
 

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
@@ -1,6 +1,7 @@
 package com.jayway.jsonassert.impl;
 
 
+import com.jayway.jsonassert.JsonAssert;
 import com.jayway.jsonassert.JsonAsserter;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
@@ -72,8 +73,10 @@ public class JsonAsserterImpl implements JsonAsserter {
         try {
             Configuration c = Configuration.defaultConfiguration();
 
-            JsonPath.using(c).parse(jsonObject).read(path);
-            throw new AssertionError(format("Document contains the path <%s> but was expected not to.", path));
+            Object obj = JsonPath.using(c).parse(jsonObject).read(path);
+            if (!JsonAssert.emptyCollection().matches(obj)) {
+                throw new AssertionError(format("Document contains the path <%s> but was expected not to.", path));
+            }
         } catch (PathNotFoundException e) {
         }
         return this;

--- a/json-path-assert/src/test/java/com/jayway/jsonpath/matchers/Issue_744.java
+++ b/json-path-assert/src/test/java/com/jayway/jsonpath/matchers/Issue_744.java
@@ -1,0 +1,21 @@
+package com.jayway.jsonpath.matchers;
+
+import com.jayway.jsonassert.JsonAssert;
+import com.jayway.jsonpath.Configuration;
+
+public class Issue_744 {
+    public static final Configuration jsonConf = Configuration.defaultConfiguration();
+
+    @org.junit.Test
+    public void test_01(){
+        String json = "{\n" +
+                "    \"array\": [\n" +
+                "        { \"name\": \"object1\" },\n" +
+                "        { \"name\": \"object2\" }\n" +
+                "    ]\n" +
+                "}";
+        JsonAssert.with(json).assertThat("array.*.fake", JsonAssert.emptyCollection());
+        JsonAssert.with(json).assertNotDefined("array.*.fake");
+    }
+
+}

--- a/json-path-assert/src/test/java/com/jayway/jsonpath/matchers/Issue_744.java
+++ b/json-path-assert/src/test/java/com/jayway/jsonpath/matchers/Issue_744.java
@@ -14,7 +14,6 @@ public class Issue_744 {
                 "        { \"name\": \"object2\" }\n" +
                 "    ]\n" +
                 "}";
-        JsonAssert.with(json).assertThat("array.*.fake", JsonAssert.emptyCollection());
         JsonAssert.with(json).assertNotDefined("array.*.fake");
     }
 


### PR DESCRIPTION
For `assertNotDefined` method, we should check the property is defined in JSON seriously, we should add the `REQUIRE_PROPERTIES` options to Configuration in order to trigger `PathNotFoundException`.