### PR TITLE
Add substring function and corresponding test cases

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
@@ -10,6 +10,7 @@ import com.jayway.jsonpath.internal.function.numeric.StandardDeviation;
 import com.jayway.jsonpath.internal.function.numeric.Sum;
 import com.jayway.jsonpath.internal.function.text.Concatenate;
 import com.jayway.jsonpath.internal.function.text.Length;
+import com.jayway.jsonpath.internal.function.text.Substring;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,6 +41,7 @@ public class PathFunctionFactory {
 
         // Text Functions
         map.put("concat", Concatenate.class);
+        map.put(Substring.TOKEN_NAME, Substring.class);
 
         // JSON Entity Functions
         map.put(Length.TOKEN_NAME, Length.class);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Substring.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/text/Substring.java
@@ -1,0 +1,73 @@
+package com.jayway.jsonpath.internal.function.text;
+
+import com.jayway.jsonpath.internal.EvaluationContext;
+import com.jayway.jsonpath.internal.PathRef;
+import com.jayway.jsonpath.internal.function.Parameter;
+import com.jayway.jsonpath.internal.function.PathFunction;
+
+import java.util.List;
+
+
+/**
+ * Getting the substring of a JSONArray Object or a String Object.
+ * This function will dump all inputs into string. Thus, it is flexible.
+ * There is a sign for books like "E" for "Military books" on the head or tail.
+ * User can use this function to work on it.
+ *
+ * Examples:
+ *    EG1:
+ *       JSON string: "{'RfRaw':{'Data':'ABC436F601F405783CE00E55'}}"
+ *       JSON-Path command: $.RfRaw.Data.substring(16,22)
+ *
+ *       The resul of "$.RfRaw.Data" is "ABC436F601F405783CE00E55"
+ *       Then get the substring "3CE00E"
+ *   EG2:
+ *       JSON string: "{'RfRaw':{'Data':'ABC436F601F405783CE00E55'}}"
+ *       JSON-Path command: $.RfRaw.substring(1,5)
+ *
+ *       The resul of "$.RfRaw.Data" is "{Data=ABC436F601F405783CE00E55}"
+ *       Then get the substring "Data"
+ *
+ *
+ * Created by XiaoLing12138 on 04/24/2022.
+ */
+public class Substring implements PathFunction {
+
+    public static final String TOKEN_NAME = "substring";
+
+    /**
+     * We can use this function to get a substring from the json file. It can be the key value which is a string or a
+     * JSON-Path Node.
+     *
+     * @param currentPath
+     *      The current path location inclusive of the function name
+     *
+     * @param parent
+     *      The path location above the current function
+     *
+     * @param model
+     *      The JSON model as input to this particular function.
+     *      You take it as the JSON object we need to deal with.
+     *
+     * @param ctx
+     *      Eval context, state bag used as the path is traversed, maintains the result of executing
+     *
+     * @param parameters
+     *      The input parameters. Here is the index of the substring
+     *
+     *
+     * @return A substring
+     */
+    @Override
+    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
+        String result = model.toString();
+        int indexHead = Integer.parseInt(parameters.get(0).getJson());
+        int indexTail = Integer.parseInt(parameters.get(1).getJson());
+
+        if (indexHead >= indexTail) {
+            return "";
+        }
+
+        return result.substring(indexHead, indexTail);
+    }
+}

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/text/SubstringTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/text/SubstringTest.java
@@ -1,0 +1,41 @@
+package com.jayway.jsonpath.internal.text;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Test;
+
+import static com.jayway.jsonpath.BaseTest.JSON_DOCUMENT;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is the test for the substring function
+ * Idea from Issue#795 user peepshow-21
+ */
+public class SubstringTest {
+
+    /**
+     * This test for the substring of a simple string
+     */
+    @Test
+    public void substringTestWithOneString() {
+        String s = JsonPath.read("{'RfRaw':{'Data':'ABC436F601F405783CE00E55'}}", "$.RfRaw.Data.substring(16,22)");
+        assertEquals("3CE00E", s);
+    }
+
+    /**
+     * This test for the substring of a node
+     */
+    @Test
+    public void substringTestWithOneNode() {
+        String s = JsonPath.read("{'RfRaw':{'Data':'ABC436F601F405783CE00E55'}}", "$.RfRaw.substring(1,5)");
+        assertEquals("Data", s);
+    }
+
+    /**
+     * This test for the substring of nodes
+     */
+    @Test
+    public void substringTestWithMulNode() {
+        String s = JsonPath.read(JSON_DOCUMENT, "$.store.book.substring(3,11)");
+        assertEquals("category", s);
+    }
+}


### PR DESCRIPTION
The idea is from [Issue#795](https://github.com/json-path/JsonPath/issues/795) raised by user [peepshow-21](https://github.com/peepshow-21).
I realize a substring function with detailed notion and test case.
This function will get the substring of the json result by index.  

I think this is useful in some cases like determining a book with it classification sign which is in certain places like the string head.

### Examples:
```
  Examples:
     EG1:
        JSON string: "{'RfRaw':{'Data':'ABC436F601F405783CE00E55'}}"
        JSON-Path command: $.RfRaw.Data.substring(16,22)
 
        The resul of "$.RfRaw.Data" is "ABC436F601F405783CE00E55"
        Then get the substring "3CE00E"
    EG2:
        JSON string: "{'RfRaw':{'Data':'ABC436F601F405783CE00E55'}}"
        JSON-Path command: $.RfRaw.substring(1,5)
 
        The resul of "$.RfRaw.Data" is "{Data=ABC436F601F405783CE00E55}"
        Then get the substring "Data"
```