### PR TITLE
fix issue #784 and add 2 tests

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -327,7 +327,7 @@ public class JsonPath {
      */
     public <T> T put(Object jsonObject, String key, Object value, Configuration configuration) {
         notNull(jsonObject, "json can not be null");
-        notEmpty(key, "key can not be null or empty");
+        notNull(key, "key can not be null or empty");
         notNull(configuration, "configuration can not be null");
         EvaluationContext evaluationContext = path.evaluate(jsonObject, jsonObject, configuration, true);
         if (evaluationContext.getPathList().isEmpty()) {
@@ -346,7 +346,7 @@ public class JsonPath {
 
     public <T> T renameKey(Object jsonObject, String oldKeyName, String newKeyName, Configuration configuration) {
         notNull(jsonObject, "json can not be null");
-        notEmpty(newKeyName, "newKeyName can not be null or empty");
+        notNull(newKeyName, "newKeyName can not be null or empty");
         notNull(configuration, "configuration can not be null");
         EvaluationContext evaluationContext = path.evaluate(jsonObject, jsonObject, configuration, true);
         for (PathRef updateOperation : evaluationContext.updateOperations()) {

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_784.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_784.java
@@ -1,0 +1,37 @@
+package com.jayway.jsonpath;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * test for issue 786
+ * Analysis: This bug is trigger when add or rename an empty but not null key.
+ */
+public class Issue_784 {
+    @Test
+    public void test_set_empty(){
+        // Try to put an empty key, if there are no exception, it's right.
+        String inputJson1="{}",inputJson2="{\"root\":{}}";
+        DocumentContext context1=JsonPath.parse(inputJson1),context2=JsonPath.parse(inputJson2);
+        boolean hasBug=false;
+        try{
+            context1.put("$","","test1");
+            context2.put("$","","test2");
+        }catch (Exception e){
+            hasBug=true;
+        }
+        Assert.assertFalse(hasBug);
+    }
+    @Test
+    public void test_renameKey(){
+        // Try to rename a key, if there are no exception, it's right.
+        String input="{\"name\":1}";
+        boolean hasBug=false;
+        DocumentContext context=JsonPath.parse(input);
+        try{
+            context.renameKey("$","name","new");
+        }catch (Exception e){
+            hasBug=true;
+        }
+        Assert.assertFalse(hasBug);
+    }
+}


### PR DESCRIPTION
Analysis: This bug is triggered when adding or renaming an empty but not null key.
- test_1: Try to put an empty key, if there is no exception, it's right.
- test_2: Try to rename a key, if there is no exception, it's right.