### PR TITLE
add unique function

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/PathFunctionFactory.java
@@ -3,6 +3,7 @@ package com.jayway.jsonpath.internal.function;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.internal.function.json.Append;
 import com.jayway.jsonpath.internal.function.json.KeySetFunction;
+import com.jayway.jsonpath.internal.function.json.Unique;
 import com.jayway.jsonpath.internal.function.numeric.Average;
 import com.jayway.jsonpath.internal.function.numeric.Max;
 import com.jayway.jsonpath.internal.function.numeric.Min;
@@ -46,6 +47,7 @@ public class PathFunctionFactory {
         map.put("size", Length.class);
         map.put("append", Append.class);
         map.put("keys", KeySetFunction.class);
+        map.put("unique", Unique.class);
 
 
         FUNCTIONS = Collections.unmodifiableMap(map);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/json/Unique.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/json/Unique.java
@@ -1,0 +1,55 @@
+package com.jayway.jsonpath.internal.function.json;
+
+import com.jayway.jsonpath.internal.EvaluationContext;
+import com.jayway.jsonpath.internal.PathRef;
+import com.jayway.jsonpath.internal.function.Parameter;
+import com.jayway.jsonpath.internal.function.PathFunction;
+import net.minidev.json.JSONArray;
+
+import java.util.List;
+import java.util.Iterator;
+import java.util.HashMap;
+
+public class Unique implements PathFunction {
+    @Override
+    public Object invoke(String currentPath, PathRef parent, Object model, EvaluationContext ctx, List<Parameter> parameters) {
+        if (null != parameters && parameters.size() > 0) {
+            Object value = parameters.get(0).getValue();
+            // the value should be list
+            if (!(value instanceof List)){
+                return value;
+            }
+            return unique(((List) value).iterator());
+        }
+        if (ctx.configuration().jsonProvider().isArray(model)) {
+            return unique(ctx.configuration().jsonProvider().toIterable(model).iterator());
+        } else if(ctx.configuration().jsonProvider().isMap(model)){
+            return model;
+        }else{
+            return model;
+        }
+    }
+
+    /**
+     * Do unique operation using HashMap.
+     * @param iterator iterator
+     * @return JSONArray
+     */
+    private JSONArray unique(Iterator<?> iterator){
+        HashMap<Integer,Object> objectHashMap = new HashMap<>();
+        int answerPosition = 0;
+        // make sure it is in order by using index as key, object as value.
+        while(iterator.hasNext()){
+            Object obj = iterator.next();
+            if(!objectHashMap.containsValue(obj)){
+                objectHashMap.put(answerPosition++,obj);
+            }
+        }
+        JSONArray result = new JSONArray();
+        for(int n = 0;n<objectHashMap.size();n++){
+            result.add(objectHashMap.get(n));
+        }
+        return result;
+    }
+
+}

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/UniqueFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/UniqueFunctionTest.java
@@ -1,0 +1,47 @@
+package com.jayway.jsonpath.internal.function;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * test for unique function
+ */
+public class UniqueFunctionTest {
+
+    private static String testJson = "{\n" +
+            "    \"items\": [\n" +
+            "    {\n" +
+            "      \"Id\": 1\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"Age\": 2,\n" +
+            "      \"Id\": 1\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"Id\": 1,\n" +
+            "      \"Age\": 2\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"Id\": 2\n" +
+            "    }\n" +
+            "]\n" +
+            "}";
+
+    @Test
+    public void testWithoutUnique(){
+        assertThat(JsonPath.read(testJson, "$..items.[*].Id").toString()).isEqualTo("[1,1,1,2]");
+        assertThat(JsonPath.read(testJson, "$..items.[*]").toString()).isEqualTo("[{\"Id\":1},{\"Age\":2,\"Id\":1},{\"Id\":1,\"Age\":2},{\"Id\":2}]");
+
+    }
+
+    @Test
+    public void testWithUnique(){
+        assertThat(JsonPath.read(testJson, "$..items.[*].Id.unique()").toString()).isEqualTo("[1,2]");
+        assertThat(JsonPath.read(testJson, "$..items.[*].unique()").toString()).isEqualTo("[{\"Id\":1},{\"Age\":2,\"Id\":1},{\"Id\":2}]");
+
+    }
+
+
+}


### PR DESCRIPTION
Add `unique()` function. The releated issue is https://github.com/json-path/JsonPath/issues/774

**Json**:

```json
{
   "items": [
      {
        "Id": 1
      },
      {
        "Age":2,
        "Id": 1
      },
      {
        "Id": 1,
        "Age":2
      },
      {
        "Id": 2
      }
   ]
}
```
You can use

`$.unique($..items[*].Id)` or `$..items[*].Id.unique()` to get result like: [1,2]

`$.unique($..items[*])` or `$..items[*].unique()` to get result like: [{"Id":1},{"Age":2,"Id":1},{"Id":2}]