### PR TITLE
fix Code bad smell

### DIFF
--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/JsonAsserterImpl.java
@@ -26,6 +26,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> JsonAsserter assertThat(String path, Matcher<T> matcher) {
         T obj = null;
@@ -48,6 +49,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> JsonAsserter assertThat(String path, Matcher<T> matcher, String message) {
         T obj = JsonPath.<T>read(jsonObject, path);
@@ -60,6 +62,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <T> JsonAsserter assertEquals(String path, T expected) {
         return assertThat(path, equalTo(expected));
     }
@@ -67,6 +70,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public JsonAsserter assertNotDefined(String path) {
 
         try {
@@ -95,6 +99,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public JsonAsserter assertNull(String path) {
         return assertThat(path, nullValue());
     }
@@ -112,6 +117,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public <T> JsonAsserter assertNotNull(String path) {
         return assertThat(path, notNullValue());
     }
@@ -124,6 +130,7 @@ public class JsonAsserterImpl implements JsonAsserter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public JsonAsserter and() {
         return this;
     }

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/CollectionMatcher.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/CollectionMatcher.java
@@ -34,6 +34,7 @@ import org.hamcrest.BaseMatcher;
 import java.util.Collection;
 
 public abstract class CollectionMatcher<C extends Collection<?>> extends BaseMatcher<C> {
+    @Override
     @SuppressWarnings("unchecked")
     public boolean matches(Object item) {
         if (!(item instanceof Collection)) {

--- a/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/MapTypeSafeMatcher.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonassert/impl/matcher/MapTypeSafeMatcher.java
@@ -34,6 +34,7 @@ import org.hamcrest.BaseMatcher;
 import java.util.Map;
 
 public abstract class MapTypeSafeMatcher<M extends Map<?, ?>> extends BaseMatcher<M> {
+    @Override
     @SuppressWarnings("unchecked")
     public boolean matches(Object item) {
         return item instanceof Map && matchesSafely((M) item);

--- a/json-path-assert/src/main/java/com/jayway/jsonpath/matchers/IsJson.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonpath/matchers/IsJson.java
@@ -29,6 +29,7 @@ public class IsJson<T> extends TypeSafeMatcher<T> {
         }
     }
 
+    @Override
     public void describeTo(Description description) {
         description.appendText("is json ").appendDescriptionOf(jsonMatcher);
     }

--- a/json-path-assert/src/main/java/com/jayway/jsonpath/matchers/WithJsonPath.java
+++ b/json-path-assert/src/main/java/com/jayway/jsonpath/matchers/WithJsonPath.java
@@ -27,6 +27,7 @@ public class WithJsonPath<T> extends TypeSafeMatcher<ReadContext> {
         }
     }
 
+    @Override
     public void describeTo(Description description) {
         description
                 .appendText("with json path ")

--- a/json-path-web-test/src/main/java/com/jayway/jsonpath/web/bench/Bench.java
+++ b/json-path-web-test/src/main/java/com/jayway/jsonpath/web/bench/Bench.java
@@ -1,20 +1,22 @@
 package com.jayway.jsonpath.web.bench;
 
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import io.gatling.jsonpath.JsonPath$;
-import org.boon.json.JsonParser;
-import org.boon.json.ObjectMapper;
-import org.boon.json.implementation.JsonParserCharArray;
-import org.boon.json.implementation.ObjectMapperImpl;
-import scala.collection.Iterator;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.boon.json.JsonParser;
+import org.boon.json.ObjectMapper;
+import org.boon.json.implementation.JsonParserCharArray;
+import org.boon.json.implementation.ObjectMapperImpl;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+
+import io.gatling.jsonpath.JsonPath$;
+import scala.collection.Iterator;
 
 public class Bench {
 
@@ -63,11 +65,6 @@ public class Bench {
         long now = System.currentTimeMillis();
         try {
             res = JsonPath.using(configuration).parse(json).read(path);
-        } catch (Exception e) {
-            error = getError(e);
-        } finally {
-            time = System.currentTimeMillis() - now;
-
             if (res instanceof String) {
                 result = "\"" + res + "\"";
             } else if (res instanceof Number) {
@@ -77,8 +74,12 @@ public class Bench {
             } else {
                 result = res != null ? Configuration.defaultConfiguration().jsonProvider().toJson(res) : "null";
             }
-            return new Result("jayway", time, result, error);
+        } catch (Exception e) {
+            error = getError(e);
+        } finally {
+            time = System.currentTimeMillis() - now;
         }
+        return new Result("jayway", time, result, error);
     }
 
     public Result runBoon() {

--- a/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Configuration.java
@@ -257,8 +257,12 @@ public class Configuration {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Configuration that = (Configuration) o;
         return jsonProvider.getClass() == that.jsonProvider.getClass() &&
                 mappingProvider.getClass() == that.mappingProvider.getClass() &&

--- a/json-path/src/main/java/com/jayway/jsonpath/Filter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Filter.java
@@ -102,6 +102,7 @@ public abstract class Filter implements Predicate {
             this(asList(left, right));
         }
 
+        @Override
         public Filter and(final Predicate other){
             Collection<Predicate> newPredicates = new ArrayList<Predicate>(predicates);
             newPredicates.add(other);
@@ -150,6 +151,7 @@ public abstract class Filter implements Predicate {
             this.right = right;
         }
 
+        @Override
         public Filter and(final Predicate other){
             return new OrFilter(left, new AndFilter(right, other));
         }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/CharacterIndex.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/CharacterIndex.java
@@ -185,8 +185,11 @@ public class CharacterIndex {
     }
 
     public char charAtOr(int postition, char defaultChar){
-        if(!inBounds(postition)) return defaultChar;
-        else return charAt(postition);
+        if(!inBounds(postition)) {
+            return defaultChar;
+        } else {
+            return charAt(postition);
+        }
     }
 
     public boolean nextSignificantCharIs(int startPosition, char c) {
@@ -255,8 +258,11 @@ public class CharacterIndex {
 
     public char previousSignificantChar(int startPosition) {
         int previousSignificantCharIndex = indexOfPreviousSignificantChar(startPosition);
-        if(previousSignificantCharIndex == -1) return ' ';
-        else return charAt(previousSignificantCharIndex);
+        if(previousSignificantCharIndex == -1) {
+            return ' ';
+        } else {
+            return charAt(previousSignificantCharIndex);
+        }
     }
 
     public char previousSignificantChar() {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonFormatter.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonFormatter.java
@@ -27,7 +27,9 @@ public class JsonFormatter {
     private static final int MODE_BETWEEN = 104;
 
     private static void appendIndent(StringBuilder sb, int count) {
-        for (; count > 0; --count) sb.append(INDENT);
+        for (; count > 0; --count) {
+            sb.append(INDENT);
+        }
     }
 
     public static String prettyPrint(String input) {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/PathRef.java
@@ -110,6 +110,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
             throw new InvalidModificationException("Invalid set operation");
         }
 
+        @Override
         public void convert(MapFunction mapFunction, Configuration configuration){
             throw new InvalidModificationException("Invalid map operation");
         }
@@ -157,19 +158,23 @@ public abstract class PathRef implements Comparable<PathRef>  {
             this.index = index;
         }
 
+        @Override
         public void set(Object newVal, Configuration configuration){
             configuration.jsonProvider().setArrayIndex(parent, index, newVal);
         }
 
+        @Override
         public void convert(MapFunction mapFunction, Configuration configuration){
             Object currentValue = configuration.jsonProvider().getArrayIndex(parent, index);
             configuration.jsonProvider().setArrayIndex(parent, index, mapFunction.map(currentValue, configuration));
         }
 
+        @Override
         public void delete(Configuration configuration){
             configuration.jsonProvider().removeProperty(parent, index);
         }
 
+        @Override
         public void add(Object value, Configuration configuration){
             Object target = configuration.jsonProvider().getArrayIndex(parent, index);
             if(targetInvalid(target)){
@@ -182,6 +187,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
             }
         }
 
+        @Override
         public void put(String key, Object value, Configuration configuration){
             Object target = configuration.jsonProvider().getArrayIndex(parent, index);
             if(targetInvalid(target)){
@@ -227,6 +233,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
             this.property = property;
         }
 
+        @Override
         public void set(Object newVal, Configuration configuration){
             configuration.jsonProvider().setProperty(parent, property, newVal);
         }
@@ -238,10 +245,12 @@ public abstract class PathRef implements Comparable<PathRef>  {
         }
 
 
+        @Override
         public void delete(Configuration configuration){
             configuration.jsonProvider().removeProperty(parent, property);
         }
 
+        @Override
         public void add(Object value, Configuration configuration){
             Object target = configuration.jsonProvider().getMapValue(parent, property);
             if(targetInvalid(target)){
@@ -254,6 +263,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
             }
         }
 
+        @Override
         public void put(String key, Object value, Configuration configuration){
             Object target = configuration.jsonProvider().getMapValue(parent, property);
             if(targetInvalid(target)){
@@ -290,11 +300,13 @@ public abstract class PathRef implements Comparable<PathRef>  {
             this.properties = properties;
         }
 
+        @Override
         public void set(Object newVal, Configuration configuration){
             for (String property : properties) {
                 configuration.jsonProvider().setProperty(parent, property, newVal);
             }
         }
+        @Override
         public void convert(MapFunction mapFunction, Configuration configuration) {
             for (String property : properties) {
                 Object currentValue = configuration.jsonProvider().getMapValue(parent, property);
@@ -304,6 +316,7 @@ public abstract class PathRef implements Comparable<PathRef>  {
             }
         }
 
+        @Override
         public void delete(Configuration configuration){
             for (String property : properties) {
                 configuration.jsonProvider().removeProperty(parent, property);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/EvaluatorFactory.java
@@ -1,12 +1,12 @@
 package com.jayway.jsonpath.internal.filter;
 
-import com.jayway.jsonpath.JsonPathException;
-import com.jayway.jsonpath.Predicate;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.Predicate;
 
 import static com.jayway.jsonpath.internal.filter.ValueNodes.PatternNode;
 import static com.jayway.jsonpath.internal.filter.ValueNodes.ValueListNode;
@@ -233,8 +233,9 @@ public class EvaluatorFactory {
                 return left.asStringNode().contains(right.asStringNode().getString());
             } else if(left.isJsonNode()){
                 ValueNode valueNode = left.asJsonNode().asValueListNode(ctx);
-                if(valueNode.isUndefinedNode()) return false;
-                else {
+                if(valueNode.isUndefinedNode()) {
+                    return false;
+                } else {
                     boolean res = valueNode.asValueListNode().contains(right);
                     return res;
                 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/FilterCompiler.java
@@ -1,15 +1,23 @@
 package com.jayway.jsonpath.internal.filter;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.jayway.jsonpath.Filter;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.CharacterIndex;
-import static com.jayway.jsonpath.internal.filter.ValueNodes.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.BooleanNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.JsonNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.NullNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.NumberNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.PathNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.PatternNode;
+import static com.jayway.jsonpath.internal.filter.ValueNodes.StringNode;
 
 public class FilterCompiler  {
     private static final Logger logger = LoggerFactory.getLogger(FilterCompiler.class);
@@ -213,7 +221,7 @@ public class FilterCompiler  {
             throw new InvalidPathException("Expected boolean literal");
         }
         CharSequence logicalOperator = filter.subSequence(begin, end+1);
-        if(!logicalOperator.equals("||") && !logicalOperator.equals("&&")){
+        if(!"||".equals(logicalOperator) && !"&&".equals(logicalOperator)){
             throw new InvalidPathException("Expected logical operator");
         }
         filter.incrementPosition(logicalOperator.length());
@@ -341,7 +349,7 @@ public class FilterCompiler  {
             throw new InvalidPathException("Expected boolean literal");
         }
         CharSequence boolValue = filter.subSequence(begin, end+1);
-        if(!boolValue.equals("true") && !boolValue.equals("false")){
+        if(!"true".equals(boolValue) && !"false".equals(boolValue)){
             throw new InvalidPathException("Expected boolean literal");
         }
         filter.incrementPosition(boolValue.length());
@@ -374,7 +382,7 @@ public class FilterCompiler  {
             }
         }
 
-        boolean shouldExists = !(previousSignificantChar == NOT);
+        boolean shouldExists = (previousSignificantChar != NOT);
         CharSequence path = filter.subSequence(begin, filter.position());
         return ValueNode.createPathNode(path, false, shouldExists);
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/LogicalOperator.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/LogicalOperator.java
@@ -24,9 +24,14 @@ public enum LogicalOperator {
     }
 
     public static LogicalOperator fromString(String operatorString){
-        if(AND.operatorString.equals(operatorString)) return AND;
-        else if(NOT.operatorString.equals(operatorString)) return NOT;
-        else if(OR.operatorString.equals(operatorString)) return OR;
-        else throw new InvalidPathException("Failed to parse operator " + operatorString);
+        if(AND.operatorString.equals(operatorString)) {
+            return AND;
+        } else if(NOT.operatorString.equals(operatorString)) {
+            return NOT;
+        } else if(OR.operatorString.equals(operatorString)) {
+            return OR;
+        } else {
+            throw new InvalidPathException("Failed to parse operator " + operatorString);
+        }
     }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
@@ -164,18 +164,33 @@ public abstract class ValueNode {
     //----------------------------------------------------
     public static ValueNode toValueNode(Object o){
 
-        if(o == null) return NULL_NODE;
-        if(o instanceof ValueNode) return (ValueNode)o;
-        if(o instanceof Class) return createClassNode((Class)o);
-        else if(isPath(o)) return new PathNode(o.toString(), false, false);
-        else if(isJson(o)) return createJsonNode(o.toString());
-        else if(o instanceof String) return createStringNode(o.toString(), true);
-        else if(o instanceof Character) return createStringNode(o.toString(), false);
-        else if(o instanceof Number) return createNumberNode(o.toString());
-        else if(o instanceof Boolean) return createBooleanNode(o.toString());
-        else if(o instanceof Pattern) return createPatternNode((Pattern)o);
-        else if (o instanceof OffsetDateTime) return createOffsetDateTimeNode(o.toString());  //workaround for issue: https://github.com/json-path/JsonPath/issues/613
-        else throw new JsonPathException("Could not determine value type");
+        if(o == null) {
+            return NULL_NODE;
+        }
+        if(o instanceof ValueNode) {
+            return (ValueNode)o;
+        }
+        if(o instanceof Class) {
+            return createClassNode((Class)o);
+        } else if(isPath(o)) {
+            return new PathNode(o.toString(), false, false);
+        } else if(isJson(o)) {
+            return createJsonNode(o.toString());
+        } else if(o instanceof String) {
+            return createStringNode(o.toString(), true);
+        } else if(o instanceof Character) {
+            return createStringNode(o.toString(), false);
+        } else if(o instanceof Number) {
+            return createNumberNode(o.toString());
+        } else if(o instanceof Boolean) {
+            return createBooleanNode(o.toString());
+        } else if(o instanceof Pattern) {
+            return createPatternNode((Pattern)o);
+        } else if (o instanceof OffsetDateTime) {
+            return createOffsetDateTimeNode(o.toString());  //workaround for issue: https://github.com/json-path/JsonPath/issues/613
+        } else {
+            throw new JsonPathException("Could not determine value type");
+        }
 
     }
 

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java
@@ -71,10 +71,12 @@ public interface ValueNodes {
             return Void.TYPE;
         }
 
+        @Override
         public boolean isPatternNode() {
             return true;
         }
 
+        @Override
         public PatternNode asPatternNode() {
             return this;
         }
@@ -91,8 +93,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof PatternNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof PatternNode)) {
+                return false;
+            }
 
             PatternNode that = (PatternNode) o;
 
@@ -117,18 +123,27 @@ public interface ValueNodes {
 
         @Override
         public Class<?> type(Predicate.PredicateContext ctx) {
-            if(isArray(ctx)) return List.class;
-            else if(isMap(ctx)) return Map.class;
-            else if(parse(ctx) instanceof Number) return Number.class;
-            else if(parse(ctx) instanceof String) return String.class;
-            else if(parse(ctx) instanceof Boolean) return Boolean.class;
-            else return Void.class;
+            if(isArray(ctx)) {
+                return List.class;
+            } else if(isMap(ctx)) {
+                return Map.class;
+            } else if(parse(ctx) instanceof Number) {
+                return Number.class;
+            } else if(parse(ctx) instanceof String) {
+                return String.class;
+            } else if(parse(ctx) instanceof Boolean) {
+                return Boolean.class;
+            } else {
+                return Void.class;
+            }
         }
 
+        @Override
         public boolean isJsonNode() {
             return true;
         }
 
+        @Override
         public JsonNode asJsonNode() {
             return this;
         }
@@ -170,8 +185,11 @@ public interface ValueNodes {
         }
 
         public boolean isEmpty(Predicate.PredicateContext ctx) {
-            if (isArray(ctx) || isMap(ctx)) return ((Collection<?>) parse(ctx)).size() == 0;
-            else if((parse(ctx) instanceof String)) return ((String)parse(ctx)).length() == 0;
+            if (isArray(ctx) || isMap(ctx)) {
+                return ((Collection<?>) parse(ctx)).size() == 0;
+            } else if((parse(ctx) instanceof String)) {
+                return ((String)parse(ctx)).length() == 0;
+            }
             return true;
         }
 
@@ -181,14 +199,20 @@ public interface ValueNodes {
         }
 
         public boolean equals(JsonNode jsonNode, Predicate.PredicateContext ctx) {
-            if (this == jsonNode) return true;
+            if (this == jsonNode) {
+                return true;
+            }
             return !(json != null ? !json.equals(jsonNode.parse(ctx)) : jsonNode.json != null);
         }
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof JsonNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof JsonNode)) {
+                return false;
+            }
 
             JsonNode jsonNode = (JsonNode) o;
 
@@ -248,10 +272,12 @@ public interface ValueNodes {
             return String.class;
         }
 
+        @Override
         public boolean isStringNode() {
             return true;
         }
 
+        @Override
         public StringNode asStringNode() {
             return this;
         }
@@ -264,8 +290,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof StringNode) && !(o instanceof NumberNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof StringNode) && !(o instanceof NumberNode)) {
+                return false;
+            }
 
             StringNode that = ((ValueNode) o).asStringNode();
 
@@ -301,10 +331,12 @@ public interface ValueNodes {
             return Number.class;
         }
 
+        @Override
         public boolean isNumberNode() {
             return true;
         }
 
+        @Override
         public NumberNode asNumberNode() {
             return this;
         }
@@ -316,8 +348,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof NumberNode) && !(o instanceof StringNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof NumberNode) && !(o instanceof StringNode)) {
+                return false;
+            }
 
             NumberNode that = ((ValueNode)o).asNumberNode();
 
@@ -357,10 +393,12 @@ public interface ValueNodes {
             return OffsetDateTimeNode.class;
         }
 
+        @Override
         public boolean isOffsetDateTimeNode() {
             return true;
         }
 
+        @Override
         public OffsetDateTimeNode asOffsetDateTimeNode() {
             return this;
         }
@@ -372,8 +410,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof OffsetDateTimeNode) && !(o instanceof StringNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof OffsetDateTimeNode) && !(o instanceof StringNode)) {
+                return false;
+            }
             OffsetDateTimeNode that = ((ValueNode)o).asOffsetDateTimeNode();
             return dateTime.compareTo(that.dateTime) == 0;
         }
@@ -393,10 +435,12 @@ public interface ValueNodes {
             return Boolean.class;
         }
 
+        @Override
         public boolean isBooleanNode() {
             return true;
         }
 
+        @Override
         public BooleanNode asBooleanNode() {
             return this;
         }
@@ -412,8 +456,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof BooleanNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BooleanNode)) {
+                return false;
+            }
 
             BooleanNode that = (BooleanNode) o;
 
@@ -437,10 +485,12 @@ public interface ValueNodes {
             return Class.class;
         }
 
+        @Override
         public boolean isClassNode() {
             return true;
         }
 
+        @Override
         public ClassNode asClassNode() {
             return this;
         }
@@ -456,8 +506,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ClassNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ClassNode)) {
+                return false;
+            }
 
             ClassNode that = (ClassNode) o;
 
@@ -491,8 +545,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof NullNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof NullNode)) {
+                return false;
+            }
 
             return true;
         }
@@ -505,10 +563,12 @@ public interface ValueNodes {
             return Void.class;
         }
 
+        @Override
         public UndefinedNode asUndefinedNode() {
             return this;
         }
 
+        @Override
         public boolean isUndefinedNode() {
             return true;
         }
@@ -531,6 +591,7 @@ public interface ValueNodes {
             return predicate;
         }
 
+        @Override
         public PredicateNode asPredicateNode() {
             return this;
         }
@@ -540,6 +601,7 @@ public interface ValueNodes {
             return Void.class;
         }
 
+        @Override
         public boolean isPredicateNode() {
             return true;
         }
@@ -587,10 +649,12 @@ public interface ValueNodes {
             return List.class;
         }
 
+        @Override
         public boolean isValueListNode() {
             return true;
         }
 
+        @Override
         public ValueListNode asValueListNode() {
             return this;
         }
@@ -602,8 +666,12 @@ public interface ValueNodes {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ValueListNode)) return false;
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ValueListNode)) {
+                return false;
+            }
 
             ValueListNode that = (ValueListNode) o;
 
@@ -656,10 +724,12 @@ public interface ValueNodes {
             return Void.class;
         }
 
+        @Override
         public boolean isPathNode() {
             return true;
         }
 
+        @Override
         public PathNode asPathNode() {
             return this;
         }
@@ -695,14 +765,23 @@ public interface ValueNodes {
                     }
                     res = ctx.configuration().jsonProvider().unwrap(res);
 
-                    if (res instanceof Number) return ValueNode.createNumberNode(res.toString());
-                    else if (res instanceof String) return ValueNode.createStringNode(res.toString(), false);
-                    else if (res instanceof Boolean) return ValueNode.createBooleanNode(res.toString());
-                    else if (res instanceof OffsetDateTime) return ValueNode.createOffsetDateTimeNode(res.toString()); //workaround for issue: https://github.com/json-path/JsonPath/issues/613
-                    else if (res == null) return NULL_NODE;
-                    else if (ctx.configuration().jsonProvider().isArray(res)) return ValueNode.createJsonNode(ctx.configuration().mappingProvider().map(res, List.class, ctx.configuration()));
-                    else if (ctx.configuration().jsonProvider().isMap(res)) return ValueNode.createJsonNode(ctx.configuration().mappingProvider().map(res, Map.class, ctx.configuration()));
-                    else throw new JsonPathException("Could not convert " + res.getClass().toString()+":"+ res.toString() + " to a ValueNode");
+                    if (res instanceof Number) {
+                        return ValueNode.createNumberNode(res.toString());
+                    } else if (res instanceof String) {
+                        return ValueNode.createStringNode(res.toString(), false);
+                    } else if (res instanceof Boolean) {
+                        return ValueNode.createBooleanNode(res.toString());
+                    } else if (res instanceof OffsetDateTime) {
+                        return ValueNode.createOffsetDateTimeNode(res.toString()); //workaround for issue: https://github.com/json-path/JsonPath/issues/613
+                    } else if (res == null) {
+                        return NULL_NODE;
+                    } else if (ctx.configuration().jsonProvider().isArray(res)) {
+                        return ValueNode.createJsonNode(ctx.configuration().mappingProvider().map(res, List.class, ctx.configuration()));
+                    } else if (ctx.configuration().jsonProvider().isMap(res)) {
+                        return ValueNode.createJsonNode(ctx.configuration().mappingProvider().map(res, Map.class, ctx.configuration()));
+                    } else {
+                        throw new JsonPathException("Could not convert " + res.getClass().toString()+":"+ res.toString() + " to a ValueNode");
+                    }
                 } catch (PathNotFoundException e) {
                     return UNDEFINED;
                 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/latebinding/PathLateBindingValue.java
@@ -42,14 +42,19 @@ public class PathLateBindingValue implements ILateBindingValue {
      *
      * @return the late value
      */
+    @Override
     public Object get() {
         return result;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         PathLateBindingValue that = (PathLateBindingValue) o;
         return Objects.equals(path, that.path) &&
                 rootDocument.equals(that.rootDocument) &&

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayIndexToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayIndexToken.java
@@ -28,8 +28,9 @@ public class ArrayIndexToken extends ArrayPathToken {
 
     @Override
     public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
-        if (!checkArrayModel(currentPath, model, ctx))
+        if (!checkArrayModel(currentPath, model, ctx)) {
             return;
+        }
         if (arrayIndexOperation.isSingleIndexOperation()) {
             handleArrayIndex(arrayIndexOperation.indexes().get(0), currentPath, model, ctx);
         } else {

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArraySliceOperation.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArraySliceOperation.java
@@ -75,7 +75,7 @@ public class ArraySliceOperation {
 
     private static Integer tryRead(String[] tokens, int idx){
         if(tokens.length > idx){
-            if(tokens[idx].equals("")){
+            if("".equals(tokens[idx])){
                 return null;
             }
             return Integer.parseInt(tokens[idx]);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArraySliceToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArraySliceToken.java
@@ -14,9 +14,10 @@
  */
 package com.jayway.jsonpath.internal.path;
 
-import com.jayway.jsonpath.internal.PathRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.jayway.jsonpath.internal.PathRef;
 
 public class ArraySliceToken extends ArrayPathToken {
 
@@ -30,8 +31,9 @@ public class ArraySliceToken extends ArrayPathToken {
 
     @Override
     public void evaluate(String currentPath, PathRef parent, Object model, EvaluationContextImpl ctx) {
-        if (!checkArrayModel(currentPath, model, ctx))
+        if (!checkArrayModel(currentPath, model, ctx)) {
             return;
+        }
         switch (operation.operation()) {
             case SLICE_FROM:
                 sliceFrom(currentPath, parent, model, ctx);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/EvaluationContextImpl.java
@@ -117,6 +117,7 @@ public class EvaluationContextImpl implements EvaluationContext {
         return rootDocument;
     }
 
+    @Override
     public Collection<PathRef> updateOperations(){
 
         Collections.sort(updateOperations);

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -1,5 +1,10 @@
 package com.jayway.jsonpath.internal.path;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.CharacterIndex;
@@ -8,11 +13,6 @@ import com.jayway.jsonpath.internal.Utils;
 import com.jayway.jsonpath.internal.filter.FilterCompiler;
 import com.jayway.jsonpath.internal.function.ParamType;
 import com.jayway.jsonpath.internal.function.Parameter;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
 
 import static java.lang.Character.isDigit;
 import static java.util.Arrays.asList;
@@ -56,7 +56,7 @@ public class PathCompiler {
 
     private Path compile() {
         RootPathToken root = readContextToken();
-        return new CompiledPath(root, root.getPathFragment().equals("$"));
+        return new CompiledPath(root, "$".equals(root.getPathFragment()));
     }
 
     public static Path compile(String path, final Predicate... filters) {
@@ -64,7 +64,7 @@ public class PathCompiler {
             CharacterIndex ci = new CharacterIndex(path);
             ci.trim();
 
-            if(!( ci.charAt(0) == DOC_CONTEXT)  && !( ci.charAt(0) == EVAL_CONTEXT)){
+            if(( ci.charAt(0) != DOC_CONTEXT)  && ( ci.charAt(0) != EVAL_CONTEXT)){
                 ci = new CharacterIndex("$." + path);
                 ci.trim();
             }
@@ -213,12 +213,14 @@ public class PathCompiler {
         if (isFunction) {
             int parenthesis_count = 1;
             for(int i = readPosition + 1; i < path.length(); i++){
-                if (path.charAt(i) == CLOSE_PARENTHESIS)
+                if (path.charAt(i) == CLOSE_PARENTHESIS) {
                     parenthesis_count--;
-                else if (path.charAt(i) == OPEN_PARENTHESIS)
+                } else if (path.charAt(i) == OPEN_PARENTHESIS) {
                     parenthesis_count++;
-                if (parenthesis_count == 0)
+                }
+                if (parenthesis_count == 0) {
                     break;
+                }
             }
 
             if (parenthesis_count != 0){

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
@@ -82,7 +82,7 @@ public abstract class PathToken {
             PathRef pathRef = ctx.forUpdate() ? PathRef.create(model, property) : PathRef.NO_OP;
             if (isLeaf()) {
                 String idx = "[" + String.valueOf(upstreamArrayIndex) + "]";
-                if(idx.equals("[-1]") || ctx.getRoot().getTail().prev().getPathFragment().equals(idx)){
+                if("[-1]".equals(idx) || ctx.getRoot().getTail().prev().getPathFragment().equals(idx)){
                     ctx.addResult(evalPath, pathRef, propertyVal);
                 }
             }

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/cache/LRUCache.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/cache/LRUCache.java
@@ -34,6 +34,7 @@ public class LRUCache implements Cache {
         this.limit = limit;
     }
 
+    @Override
     public void put(String key, JsonPath value) {
         JsonPath oldValue = map.put(key, value);
         if (oldValue != null) {
@@ -46,6 +47,7 @@ public class LRUCache implements Cache {
         }
     }
 
+    @Override
     public JsonPath get(String key) {
         JsonPath jsonPath = map.get(key);
         if(jsonPath != null){
@@ -106,6 +108,7 @@ public class LRUCache implements Cache {
         return map.size();
     }
 
+    @Override
     public String toString() {
         return map.toString();
     }

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/AbstractJsonProvider.java
@@ -14,11 +14,11 @@
  */
 package com.jayway.jsonpath.spi.json;
 
-import com.jayway.jsonpath.JsonPathException;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import com.jayway.jsonpath.JsonPathException;
 
 public abstract class AbstractJsonProvider implements JsonProvider {
 
@@ -28,6 +28,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj object to check
      * @return true if obj is an array
      */
+    @Override
     public boolean isArray(Object obj) {
         return (obj instanceof List);
     }
@@ -39,15 +40,18 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param idx index
      * @return the entry at the given index
      */
+    @Override
     public Object getArrayIndex(Object obj, int idx) {
         return ((List) obj).get(idx);
     }
 
+    @Override
     @Deprecated
     public final Object getArrayIndex(Object obj, int idx, boolean unwrap){
         return getArrayIndex(obj, idx);
     }
 
+    @Override
     public void setArrayIndex(Object array, int index, Object newValue) {
         if (!isArray(array)) {
             throw new UnsupportedOperationException();
@@ -69,6 +73,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param key property key
      * @return the map entry or {@link com.jayway.jsonpath.spi.json.JsonProvider#UNDEFINED} for missing properties
      */
+    @Override
     public Object getMapValue(Object obj, String key){
         Map m = (Map) obj;
         if(!m.containsKey(key)){
@@ -85,11 +90,12 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param key   a String key
      * @param value the value to set
      */
+    @Override
     @SuppressWarnings("unchecked")
     public void setProperty(Object obj, Object key, Object value) {
-        if (isMap(obj))
+        if (isMap(obj)) {
             ((Map) obj).put(key.toString(), value);
-        else {
+        } else {
             throw new JsonPathException("setProperty operation cannot be used with " + obj!=null?obj.getClass().getName():"null");
         }
     }
@@ -102,11 +108,12 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj   an array or an object
      * @param key   a String key or a numerical index to remove
      */
+    @Override
     @SuppressWarnings("unchecked")
     public void removeProperty(Object obj, Object key) {
-        if (isMap(obj))
+        if (isMap(obj)) {
             ((Map) obj).remove(key.toString());
-        else {
+        } else {
             List list = (List) obj;
             int index = key instanceof Integer ? (Integer) key : Integer.parseInt(key.toString());
             list.remove(index);
@@ -120,6 +127,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj object to check
      * @return true if the object is a map
      */
+    @Override
     public boolean isMap(Object obj) {
         return (obj instanceof Map);
     }
@@ -130,6 +138,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj an object
      * @return the keys for an object
      */
+    @Override
     @SuppressWarnings("unchecked")
     public Collection<String> getPropertyKeys(Object obj) {
         if (isArray(obj)) {
@@ -145,6 +154,7 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj an array or an object
      * @return the number of entries in the array or object
      */
+    @Override
     public int length(Object obj) {
         if (isArray(obj)) {
             return ((List) obj).size();
@@ -163,12 +173,14 @@ public abstract class AbstractJsonProvider implements JsonProvider {
      * @param obj an array
      * @return an Iterable that iterates over the entries of an array
      */
+    @Override
     @SuppressWarnings("unchecked")
     public Iterable<?> toIterable(Object obj) {
-        if (isArray(obj))
+        if (isArray(obj)) {
             return ((Iterable) obj);
-        else
+        } else {
             throw new JsonPathException("Cannot iterate over " + obj!=null?obj.getClass().getName():"null");
+        }
     }
 
     @Override

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/GsonJsonProvider.java
@@ -14,15 +14,6 @@
  */
 package com.jayway.jsonpath.spi.json;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
-import com.jayway.jsonpath.InvalidJsonException;
-import com.jayway.jsonpath.JsonPathException;
-
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
@@ -32,6 +23,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.JsonPathException;
 
 public class GsonJsonProvider extends AbstractJsonProvider {
 
@@ -54,6 +54,7 @@ public class GsonJsonProvider extends AbstractJsonProvider {
         this.gson = gson;
     }
 
+    @Override
     public Object unwrap(final Object o) {
 
         if (o == null) {
@@ -205,6 +206,7 @@ public class GsonJsonProvider extends AbstractJsonProvider {
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public void removeProperty(final Object obj, final Object key) {
         if (isMap(obj)) {

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JacksonJsonNodeJsonProvider.java
@@ -92,6 +92,7 @@ public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
         return JsonNodeFactory.instance.objectNode();
     }
 
+    @Override
     public Object unwrap(Object o) {
         if (o == null) {
             return null;
@@ -184,6 +185,7 @@ public class JacksonJsonNodeJsonProvider extends AbstractJsonProvider {
         }
 	}
 
+    @Override
     public void removeProperty(Object obj, Object key) {
         if (isMap(obj)) {
             toJsonObject(obj).remove(key.toString());

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JakartaJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JakartaJsonProvider.java
@@ -1,19 +1,5 @@
 package com.jayway.jsonpath.spi.json;
 
-import com.jayway.jsonpath.InvalidJsonException;
-import com.jayway.jsonpath.JsonPathException;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonNumber;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonString;
-import jakarta.json.JsonStructure;
-import jakarta.json.JsonValue;
-import jakarta.json.spi.JsonProvider;
-import jakarta.json.stream.JsonParsingException;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -34,6 +20,22 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+
+import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.JsonPathException;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+import jakarta.json.spi.JsonProvider;
+import jakarta.json.stream.JsonParsingException;
 
 
 public class JakartaJsonProvider extends AbstractJsonProvider {
@@ -218,6 +220,7 @@ public class JakartaJsonProvider extends AbstractJsonProvider {
         }
     }
 
+    @Override
     @SuppressWarnings("rawtypes")
     public void removeProperty(Object obj, Object key) {
         if (obj instanceof JsonObjectBuilder) {

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JettisonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JettisonProvider.java
@@ -325,7 +325,8 @@ public class JettisonProvider extends AbstractJsonProvider
 
 	}
 
-	public Collection<String> getPropertyKeys(Object obj) 
+	@Override
+    public Collection<String> getPropertyKeys(Object obj)
 	{
 		List<String> keys = new ArrayList<String>(length(obj));
 		

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
@@ -107,9 +107,9 @@ public class JsonOrgJsonProvider extends AbstractJsonProvider {
     @Override
     public void setProperty(Object obj, Object key, Object value) {
         try {
-            if (isMap(obj))
+            if (isMap(obj)) {
                 toJsonObject(obj).put(key.toString(), createJsonElement(value));
-            else {
+            } else {
                 JSONArray array = toJsonArray(obj);
                 int index;
                 if (key != null) {
@@ -128,11 +128,12 @@ public class JsonOrgJsonProvider extends AbstractJsonProvider {
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public void removeProperty(Object obj, Object key) {
-        if (isMap(obj))
+        if (isMap(obj)) {
             toJsonObject(obj).remove(key.toString());
-        else {
+        } else {
             JSONArray array = toJsonArray(obj);
             int index = key instanceof Integer ? (Integer) key : Integer.parseInt(key.toString());
             array.remove(index);
@@ -149,8 +150,9 @@ public class JsonOrgJsonProvider extends AbstractJsonProvider {
     public Collection<String> getPropertyKeys(Object obj) {
         JSONObject jsonObject = toJsonObject(obj);
         try {
-            if(Objects.isNull(jsonObject.names()))
+            if(Objects.isNull(jsonObject.names())) {
                 return new ArrayList<>();
+            }
             return jsonObject.keySet();
         } catch (JSONException e) {
             throw new JsonPathException(e);

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonSmartJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonSmartJsonProvider.java
@@ -49,14 +49,17 @@ public class JsonSmartJsonProvider extends AbstractJsonProvider {
         this.mapper = mapper;
     }
 
+    @Override
     public Object createArray() {
         return mapper.createArray();
     }
 
+    @Override
     public Object createMap() {
         return mapper.createObject();
     }
 
+    @Override
     public Object parse(String json) {
         try {
             return createParser().parse(json, mapper);

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JsonSmartMappingProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/mapper/JsonSmartMappingProvider.java
@@ -98,6 +98,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public StringReader() {
             super(null);
         }
+        @Override
         public String convert(Object src) {
             if(src == null){
                 return null;
@@ -109,6 +110,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public IntegerReader() {
             super(null);
         }
+        @Override
         public Integer convert(Object src) {
             if(src == null){
                 return null;
@@ -133,6 +135,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public LongReader() {
             super(null);
         }
+        @Override
         public Long convert(Object src) {
             if(src == null){
                 return null;
@@ -158,6 +161,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public DoubleReader() {
             super(null);
         }
+        @Override
         public Double convert(Object src) {
             if(src == null){
                 return null;
@@ -182,6 +186,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public FloatReader() {
             super(null);
         }
+        @Override
         public Float convert(Object src) {
             if(src == null){
                 return null;
@@ -206,6 +211,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public BigDecimalReader() {
             super(null);
         }
+        @Override
         public BigDecimal convert(Object src) {
             if(src == null){
                 return null;
@@ -217,6 +223,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public BigIntegerReader() {
             super(null);
         }
+        @Override
         public BigInteger convert(Object src) {
             if(src == null){
                 return null;
@@ -228,6 +235,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public DateReader() {
             super(null);
         }
+        @Override
         public Date convert(Object src) {
             if(src == null){
                 return null;
@@ -250,6 +258,7 @@ public class JsonSmartMappingProvider implements MappingProvider {
         public BooleanReader() {
             super(null);
         }
+        @Override
         public Boolean convert(Object src) {
             if(src == null){
                 return null;


### PR DESCRIPTION
An overridden method from an interface or abstract class must be marked with @Override annotation. Counter example: For getObject() and get0bject(), the first one has a letter 'O', and the second one has a number '0'. To accurately determine whether the overriding is successful, an @Override annotation is necessary. Meanwhile, once the method signature in the abstract class is changed, the implementation class will report a compile-time error immediately.

Braces are used with if, else, for, do and while statements, even if the body contains only a single statement. Avoid using the following example: if (condition) statements; 

Since NullPointerException can possibly be thrown while calling the equals method of Object, equals should be invoked by a constant or an object that is definitely not null.