### PR TITLE
support feature for issue #803

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -14,6 +14,7 @@
  */
 package com.jayway.jsonpath.internal;
 
+import com.google.gson.GsonBuilder;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.EvaluationListener;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static com.jayway.jsonpath.JsonPath.compile;
@@ -79,7 +81,15 @@ public class JsonContext implements DocumentContext {
 
     @Override
     public <T> T read(String path, Class<T> type, Predicate... filters) {
-        return convert(read(path, filters), type, configuration);
+        Object obj = read(path, filters);
+        if (type == String.class && obj != null && obj.getClass() == LinkedHashMap.class) {
+            return (T) new GsonBuilder()
+                    .serializeNulls()
+                    .setPrettyPrinting()
+                    .create()
+                    .toJson(obj, LinkedHashMap.class);
+        }
+        return convert(obj, type, configuration);
     }
 
     @Override
@@ -90,7 +100,15 @@ public class JsonContext implements DocumentContext {
 
     @Override
     public <T> T read(JsonPath path, Class<T> type) {
-        return convert(read(path), type, configuration);
+        Object obj = read(path);
+        if (type == String.class && obj != null && obj.getClass() == LinkedHashMap.class) {
+            return (T) new GsonBuilder()
+                    .serializeNulls()
+                    .setPrettyPrinting()
+                    .create()
+                    .toJson(obj, LinkedHashMap.class);
+        }
+        return convert(obj, type, configuration);
     }
 
     @Override

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_803.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_803.java
@@ -1,0 +1,16 @@
+package com.jayway.jsonpath;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class Issue_803 extends BaseTest {
+    @Test
+    public void testLinkedHashMap() {
+        // Replace all whitespaces
+        assertEquals(JSON_BOOK_STORE_DOCUMENT.replaceAll("\\s+",""),
+                JsonPath.parse(JSON_BOOK_STORE_DOCUMENT).read("$", String.class).replaceAll("\\s+",""));
+        // ReadContext.read escape HTML, so we replace "\\u002A" with "*" in JSON_DOCUMENT
+        assertEquals(JSON_DOCUMENT.replaceAll("\\s+","").replace("\\u002A", "*"),
+                JsonPath.parse(JSON_DOCUMENT).read("$", String.class).replaceAll("\\s+",""));
+    }
+}


### PR DESCRIPTION
Support the feature proposed in issue #803. 
A user can obtain the json string by calling `read(jsonpath, String.class)`. For example,
```
String str = JsonPath.parse(JSON_BOOK_STORE_DOCUMENT).read("$.store", String.class);
```
and you will get
```
{
  "book": [
    {
      "category": "reference"
    },
    {
      "category": "fiction"
    },
    {
      "category": "fiction"
    },
    {
      "category": "fiction"
    }
  ]
}
```