### PR TITLE
add feature for issue #830 and add two testcase

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -18,12 +18,17 @@ package com.jayway.jsonpath;
 import com.jayway.jsonpath.internal.*;
 import com.jayway.jsonpath.internal.path.PathCompiler;
 import com.jayway.jsonpath.spi.json.JsonProvider;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import static com.jayway.jsonpath.Option.ALWAYS_RETURN_LIST;
 import static com.jayway.jsonpath.Option.AS_PATH_LIST;
@@ -419,6 +424,15 @@ public class JsonPath {
         return read(jsonFile, Configuration.defaultConfiguration());
     }
 
+    @SuppressWarnings({"unchecked"})
+    public static List<DocumentContext> parse(JSONArray jsonArray) {
+        List<DocumentContext> documentContextList = new ArrayList<>();
+        for (Object o: jsonArray.toArray()) {
+            JSONObject jsonObject = new JSONObject((Map<String, ?>) o);
+            documentContextList.add(new ParseContextImpl().parse(jsonObject.toJSONString()));
+        }
+        return documentContextList;
+    }
 
     /**
      * Applies this JsonPath to the provided json file

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_830.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_830.java
@@ -1,0 +1,67 @@
+package com.jayway.jsonpath;
+
+import net.minidev.json.JSONArray;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue_830 {
+
+    private final String json = "{\n" +
+            "    \"some\": {\n" +
+            "        \"nested\": {\n" +
+            "            \"path\": [\n" +
+            "                {\n" +
+            "                    \"id\": 1,\n" +
+            "                    \"name\": \"one\",\n" +
+            "                    \"data\": {\n" +
+            "                        \"field\": \"value\"\n" +
+            "                    }\n" +
+            "                },\n" +
+            "                {\n" +
+            "                    \"id\": 2,\n" +
+            "                    \"name\": \"two\",\n" +
+            "                    \"data\": {\n" +
+            "                        \"needlessly\": {\n" +
+            "                            \"nested\": {\n" +
+            "                                \"field\": \"value\"\n" +
+            "                            }\n" +
+            "                        }\n" +
+            "                    }\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }\n" +
+            "    }\n" +
+            "}";
+
+    @Test
+    public void testFeature_1() {
+        InputStream inputStream = new ByteArrayInputStream(json.getBytes());
+        DocumentContext documentContext = JsonPath.parse(inputStream);
+        JSONArray items = documentContext.read("$['some']['nested']['path'][*]");
+        List<DocumentContext> contextList = JsonPath.parse(items);
+        List<String> ans = new ArrayList<>();
+        for (DocumentContext context: contextList) {
+            ans.add(context.read("$['data']").toString());
+        }
+        assertThat(ans.toString()).isEqualTo("[{field=value}, {needlessly={nested={field=value}}}]");
+    }
+
+    @Test
+    public void testFeature_2() {
+        InputStream inputStream = new ByteArrayInputStream(json.getBytes());
+        DocumentContext documentContext = JsonPath.parse(inputStream);
+        JSONArray items = documentContext.read("$['some']['nested']['path'][*]");
+        List<DocumentContext> contextList = JsonPath.parse(items);
+        List<String> ans = new ArrayList<>();
+        for (DocumentContext context: contextList) {
+            ans.add(context.read("$['name']").toString());
+        }
+        assertThat(ans.toString()).isEqualTo("[one, two]");
+    }
+}


### PR DESCRIPTION
The feature in  issue #830 is about the ability to get a collection of DocumentContext for the json structure that represents each item, which is helpful for users to read JsonPath for each item.