### PR TITLE
Upgrade Jackson-databind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     libs = [
             gson: 'com.google.code.gson:gson:2.8.9',
             hamcrest: 'org.hamcrest:hamcrest:2.2',
-            jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2',
+            jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2',
             jettison: 'org.codehaus.jettison:jettison:1.5.1',
             jsonOrg: 'org.json:json:20140107',
             jsonSmart: 'net.minidev:json-smart:2.4.8',


### PR DESCRIPTION
Upgrading Jackson-databind to mitigate CVEs in 2.13.2.2. This requires 2.13.4.2