### PR TITLE
add copyright and license to jar

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,13 @@
+Copyright 2017 Jayway
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/json-path-assert/build.gradle
+++ b/json-path-assert/build.gradle
@@ -2,6 +2,11 @@
 description = "Assertions on Json using JsonPath"
 
 jar {
+    from('../') {
+        include 'LICENSE'
+        include 'COPYRIGHT'
+    }
+
     baseName 'json-path-assert'
     bnd (
         'Implementation-Title': 'json-path-assert', 'Implementation-Version': version

--- a/json-path-web-test/build.gradle
+++ b/json-path-web-test/build.gradle
@@ -17,6 +17,11 @@ task createBuildInfoFile {
 }
 
 jar {
+    from('../') {
+        include 'LICENSE'
+        include 'COPYRIGHT'
+    }
+
     dependsOn createBuildInfoFile
     baseName 'json-path-web-test'
     bnd (

--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -2,6 +2,11 @@
 description = "Java port of Stefan Goessner JsonPath."
 
 jar {
+    from('../') {
+        include 'LICENSE'
+        include 'COPYRIGHT'
+    }
+
     baseName 'json-path'
     bnd (
         'Implementation-Title': 'json-path', 'Implementation-Version': version,


### PR DESCRIPTION
### Add copyright and license information to Jar.

For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from the Jar file. Therefore it would be great to have the copyright and license  information included in the Jar file as COPYRIGHT and LICENSE files. 