### PR TITLE
Use alternative property names for the deprecated properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,10 @@ subprojects {
             mavenJava(MavenPublication) {
                 from components.java
 
-                artifactId = jar.baseName
+                artifactId = jar.archiveBaseName
 
                 pom {
-                    name = jar.baseName
+                    name = jar.archiveBaseName
                     description = project.description
                     url = 'https://github.com/jayway/JsonPath'
 

--- a/json-path-assert/build.gradle
+++ b/json-path-assert/build.gradle
@@ -2,9 +2,9 @@
 description = "Assertions on Json using JsonPath"
 
 jar {
-    baseName 'json-path-assert'
+    archiveBaseName = 'json-path-assert'
     bnd (
-        'Implementation-Title': 'json-path-assert', 'Implementation-Version': version
+        'Implementation-Title': 'json-path-assert', 'Implementation-Version': archiveVersion
     )
 }
 

--- a/json-path-web-test/build.gradle
+++ b/json-path-web-test/build.gradle
@@ -18,10 +18,10 @@ task createBuildInfoFile {
 
 jar {
     dependsOn createBuildInfoFile
-    baseName 'json-path-web-test'
+    archiveVersion = 'json-path-web-test'
     bnd (
         'Implementation-Title': 'json-path-web-test',
-        'Implementation-Version': version,
+        'Implementation-Version': archiveVersion,
         'Main-Class': mainClassName
     )
 }

--- a/json-path/build.gradle
+++ b/json-path/build.gradle
@@ -2,9 +2,9 @@
 description = "Java port of Stefan Goessner JsonPath."
 
 jar {
-    baseName 'json-path'
+    archiveBaseName = 'json-path'
     bnd (
-        'Implementation-Title': 'json-path', 'Implementation-Version': version,
+        'Implementation-Title': 'json-path', 'Implementation-Version': archiveVersion,
         'Import-Package': 'org.json.*;resolution:=optional, com.google.gson.*;resolution:=optional, com.fasterxml.jackson.*;resolution:=optional, org.apache.tapestry5.json.*;resolution:=optional, org.codehaus.jettison.*;resolution:=optional, jakarta.json.*;resolution:=optional, *',
         'Export-Package': 'com.jayway.jsonpath,com.jayway.jsonpath.spi,com.jayway.jsonpath.spi.cache,com.jayway.jsonpath.spi.json,com.jayway.jsonpath.spi.mapper'
     )
@@ -68,9 +68,9 @@ task distZip(type: Zip, dependsOn: assemble) {
 }
 
 task distTar(type: Tar, dependsOn: assemble) {
-    classifier = 'with-dependencies'
+    archiveClassifier = 'with-dependencies'
     compression = Compression.GZIP
-    extension = 'tar.gz'
+    archiveExtension = 'tar.gz'
 
     from('build/docs') {
         into 'api'


### PR DESCRIPTION
When running the gradle build locally, several warnings are popping up due to the use of deprecated property names. This can be visible if the build is executed with the command: 

`gradlew build -Dorg.gradle.warning.mode=fail`

The solution is to update the deprecated properties.