### PR TITLE
Upgrade org.json:json from 20140107 to 20230227

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext {
             hamcrest: 'org.hamcrest:hamcrest:2.2',
             jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.14.2',
             jettison: 'org.codehaus.jettison:jettison:1.5.4',
-            jsonOrg: 'org.json:json:20140107',
+            jsonOrg: 'org.json:json:20230227',
             tapestryJson: 'org.apache.tapestry:tapestry-json:5.8.1',
             jakartaJsonP: 'jakarta.json:jakarta.json-api:2.0.1',
             jakartaJsonB: 'jakarta.json.bind:jakarta.json.bind-api:2.0.0',

--- a/json-path/src/test/java/com/jayway/jsonpath/InlineFilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/InlineFilterTest.java
@@ -4,8 +4,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.jayway.jsonpath.JsonPath.using;
 import static com.jayway.jsonpath.TestUtils.assertHasNoResults;
@@ -73,9 +75,14 @@ public class InlineFilterTest extends BaseTest {
 
     @Test
     public void root_context_can_be_referred_in_predicate() {
-        List<Double> prices = using(conf).parse(JSON_DOCUMENT).read("store.book[?(@.display-price <= $.max-price)].display-price", List.class);
+        List<?> prices = using(conf).parse(JSON_DOCUMENT).read("store.book[?(@.display-price <= $.max-price)].display-price", List.class);
 
-        assertThat(prices).containsAll(asList(8.95D, 8.99D));
+        assertThat(prices.stream().map(this::asDouble)).containsAll(asList(8.95D, 8.99D));
+    }
+
+    private Double asDouble(Object object) {
+        // For json-org implementation returns a list of big decimals
+        return object instanceof BigDecimal ? ((BigDecimal) object).doubleValue() : (Double) object;
     }
 
     @Test

--- a/json-path/src/test/java/com/jayway/jsonpath/InlineFilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/InlineFilterTest.java
@@ -7,7 +7,6 @@ import org.junit.runners.Parameterized;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.jayway.jsonpath.JsonPath.using;
 import static com.jayway.jsonpath.TestUtils.assertHasNoResults;


### PR DESCRIPTION
This PR upgrades the optional dependency `org.json:json` from 20140107 to 20230227.
It's good to keep dependencies up-to-date.
A Junit test was adapted since the newest versions of JSON-Java use BigDecimals for double values.