### PR TITLE
Fix ClassCastException when filer contains empty

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java
@@ -170,7 +170,17 @@ public interface ValueNodes {
         }
 
         public boolean isEmpty(Predicate.PredicateContext ctx) {
-            if (isArray(ctx) || isMap(ctx)) return ((Collection<?>) parse(ctx)).size() == 0;
+            if (isArray(ctx) || isMap(ctx)) {
+                Object parsedObj = parse(ctx);
+                if (parsedObj instanceof Collection) {
+                    return ((Collection<?>) parsedObj).size() == 0;
+                } else if (parsedObj instanceof Map) {
+                    return ((Map<?, ?>) parsedObj).isEmpty();
+                } else {
+                    throw new IllegalArgumentException("Expected a Collection or Map object, but got " +
+                            parsedObj.getClass().getSimpleName());
+                }
+            }
             else if((parse(ctx) instanceof String)) return ((String)parse(ctx)).length() == 0;
             return true;
         }

--- a/json-path/src/test/java/com/jayway/jsonpath/EmptyFilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/EmptyFilterTest.java
@@ -1,0 +1,48 @@
+package com.jayway.jsonpath;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * test for issue 900
+ */
+public class EmptyFilterTest {
+
+    @Test
+    public void test() {
+        String json = "{\n" +
+                "  \"data1\": {\n" +
+                "    \"data\": [\n" +
+                "      {\n" +
+                "        \"attribute1\": \"string1\",\n" +
+                "        \"attribute2\": \"string2\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"attribute1\": \"string3\",\n" +
+                "        \"attribute2\": \"string4\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"data2\": {\n" +
+                "    \"data\": [\n" +
+                "      {}\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"data3\": {\n" +
+                "    \"data\": [\n" +
+                "      {\n" +
+                "        \"attribute1\": \"string5\",\n" +
+                "        \"attribute2\": \"string6\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"attribute1\": \"string7\",\n" +
+                "        \"attribute2\": \"string8\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}";
+        JsonPath jsonPath = JsonPath.compile("$..data.*[?(@ empty false)]");
+        Object jsonPathValue = jsonPath.read(json);
+        Assert.assertNotNull(jsonPathValue);
+    }
+}


### PR DESCRIPTION
This commit fixes the https://github.com/json-path/JsonPath/issues/900
Adds a test case to check the empty filter ClassCastException