### PR TITLE
Update README.md: Fix Filter Operators section header

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The function output is dictated by the function itself.
 | first()   | Provides the first item of an array                                                  | Depends on the array |
 | last()    | Provides the last item of an array                                                   | Depends on the array |
 | index(X)  | Provides the item of an array of index: X, if the X is negative, take from backwards | Depends on the array |
+
+
 Filter Operators
 -----------------
 


### PR DESCRIPTION
Filter Operators section header was getting squashed into Functions table (at least when rendered on github).

I assume from context and looking at the source this was meant to be a section headed.

Added a couple lines to fix it 