### PR TITLE
Support pushing the webserver to fly.io instead of heroku

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
         classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:6.1.0'
+        classpath 'com.palantir.gradle.docker:gradle-docker:0.35.0'
     }
 }
 

--- a/json-path-web-test/Dockerfile
+++ b/json-path-web-test/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:11-jre-jammy
+
+ARG VERSION
+ARG SLF4J_VERSION=1.7.36
+
+WORKDIR /opt/app
+EXPOSE 8080
+
+ADD json-path-web-test-${VERSION}.tar /opt/app/
+RUN mv json-path-web-test-${VERSION} json-path-web-test
+ADD https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/${SLF4J_VERSION}/slf4j-simple-${SLF4J_VERSION}.jar /opt/classpath/
+
+CMD ["java", "-classpath", "/opt/app/json-path-web-test/lib/*:/opt/classpath/*", "com.jayway.jsonpath.web.boot.Main"]

--- a/json-path-web-test/build.gradle
+++ b/json-path-web-test/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'application'
+apply plugin: 'com.palantir.docker'
 
 description = "Web app that compares different JsonPath implementations."
 
@@ -26,6 +27,19 @@ jar {
     )
 }
 
+docker {
+    name "registry.fly.io/jsonpath:" + project.version.toString()
+    files tasks.distTar.outputs
+    buildArgs([VERSION: project.version.toString(), SLF4J_VERSION: libs.slf4jApi.substring(libs.slf4jApi.lastIndexOf(":") + 1)])
+    buildx true
+    platform "linux/amd64"
+}
+
+task flyDeploy(type: Exec) {
+    //dependsOn "dockerPush" + project.version.toString()
+    commandLine 'fly', 'deploy', '--image=registry.fly.io/jsonpath:' + project.version.toString()
+}
+
 
 dependencies {
     implementation project(':json-path')
@@ -36,8 +50,8 @@ dependencies {
     implementation 'io.fastjson:boon:0.33'
     implementation 'com.nebhale.jsonpath:jsonpath:1.2'
     implementation 'io.gatling:jsonpath_2.10:0.6.4'
-    implementation 'org.eclipse.jetty:jetty-server:9.3.0.M1'
-    implementation 'org.eclipse.jetty:jetty-webapp:9.3.0.M1'
+    implementation 'org.eclipse.jetty:jetty-server:9.4.51.v20230217'
+    implementation 'org.eclipse.jetty:jetty-webapp:9.4.51.v20230217'
     implementation 'org.glassfish.jersey.containers:jersey-container-servlet:2.20'
     implementation('org.glassfish.jersey.media:jersey-media-json-jackson:2.20'){
         exclude module: 'jackson-annotations:com.fasterxml.jackson.core'

--- a/json-path-web-test/fly.toml
+++ b/json-path-web-test/fly.toml
@@ -1,0 +1,21 @@
+app = "jsonpath"
+primary_region = "sea"
+
+[build]
+  image = "registry.fly.io/jsonpath-eval"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+
+[checks]
+  [checks.info]
+    port = 8080
+    type = "http"
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "5s"
+    method = "get"
+    path = "/api/info"


### PR DESCRIPTION
The old jsonpath.herokuapp.com appears to have gone offline when Heroku discontinued free services. Fly.io still offers a basic free service that is perfect for running this app.

I've set that up an organization on fly.io that I'm happy to move over to someone elses control. The benefit is that it has the domain https://jsonpath.fly.dev mirroring as close as possible the old herokuapp.com domain.