### PR TITLE
Adding STRICT_MODE option for jsonpath filters

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/Option.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/Option.java
@@ -83,6 +83,31 @@ public enum Option {
      * If REQUIRE_PROPERTIES option is present PathNotFoundException is thrown.
      * If REQUIRE_PROPERTIES option is not present ["b-val"] is returned.
      */
-    REQUIRE_PROPERTIES
+    REQUIRE_PROPERTIES,
+
+    /**
+     * Configures JsonPath to require all properties defined in filters.
+     *
+     *
+     * Given:
+     *
+     * <pre>
+     * [
+     *     {
+     *         "a" : "a-val",
+     *         "b" : "b-val"
+     *     },
+     *     {
+     *         "a" : "a-val",
+     *     }
+     * ]
+     * </pre>
+     *
+     * evaluating the filter "[?(@['does_not_exist'] NIN ['1', '2'])]"
+     *
+     * If STRICT_MODE option is present, filter will evaluate to false.
+     * If STRICT_MODE option is not present, filter will evaluate to true.
+     */
+    STRICT_MODE
 
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalExpressionNode.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/RelationalExpressionNode.java
@@ -1,5 +1,6 @@
 package com.jayway.jsonpath.internal.filter;
 
+import com.jayway.jsonpath.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,9 @@ public class RelationalExpressionNode extends ExpressionNode {
         }
         if(right.isPathNode()){
             r = right.asPathNode().evaluate(ctx);
+        }
+        if (ctx.configuration().containsOption(Option.STRICT_MODE) && (l.isUndefinedNode() || r.isUndefinedNode())) {
+            return false;
         }
         Evaluator evaluator = EvaluatorFactory.createEvaluator(relationalOperator);
         if(evaluator != null){

--- a/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/BaseTest.java
@@ -153,8 +153,8 @@ public class BaseTest {
             "    \"expensive\": 10\n" +
             "}";
 
-    public Predicate.PredicateContext createPredicateContext(final Object check) {
+    public Predicate.PredicateContext createPredicateContext(final Object check, Option... options) {
 
-        return new PredicateContextImpl(check, check, Configuration.defaultConfiguration(), new HashMap<Path, Object>());
+        return new PredicateContextImpl(check, check, Configuration.defaultConfiguration().setOptions(options), new HashMap<Path, Object>());
     }
 }

--- a/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
@@ -14,9 +14,11 @@ import java.util.regex.Pattern;
 import static com.jayway.jsonpath.Criteria.where;
 import static com.jayway.jsonpath.Filter.filter;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class FilterTest extends BaseTest {
 
@@ -156,14 +158,14 @@ public class FilterTest extends BaseTest {
         check.put("item", 3);
         check.put("null_item", null);
 
-//        assertTrue(filter(where("item").nin(4, 5)).apply(createPredicateContext(check)));
-//        assertTrue(filter(where("item").nin(asList(4, 5))).apply(createPredicateContext(check)));
-//        assertTrue(filter(where("item").nin(asList('A'))).apply(createPredicateContext(check)));
-//        assertTrue(filter(where("null_item").nin(1, 2, 3)).apply(createPredicateContext(check)));
-//        assertTrue(filter(where("item").nin(asList((Object) null))).apply(createPredicateContext(check)));
-//
-//        assertFalse(filter(where("item").nin(3)).apply(createPredicateContext(check)));
-//        assertFalse(filter(where("item").nin(asList(3))).apply(createPredicateContext(check)));
+        assertTrue(filter(where("item").nin(4, 5)).apply(createPredicateContext(check)));
+        assertTrue(filter(where("item").nin(asList(4, 5))).apply(createPredicateContext(check)));
+        assertTrue(filter(where("item").nin(asList('A'))).apply(createPredicateContext(check)));
+        assertTrue(filter(where("null_item").nin(1, 2, 3)).apply(createPredicateContext(check)));
+        assertTrue(filter(where("item").nin(asList((Object) null))).apply(createPredicateContext(check)));
+
+        assertFalse(filter(where("item").nin(3)).apply(createPredicateContext(check)));
+        assertFalse(filter(where("item").nin(asList(3))).apply(createPredicateContext(check)));
         assertFalse(filter(where("not_existent_item").nin(3)).apply(createPredicateContext(check, Option.STRICT_MODE)));
         assertFalse(filter(where("not_existent_item").nin(asList(3))).apply(createPredicateContext(check, Option.STRICT_MODE)));
     }

--- a/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
@@ -1,6 +1,11 @@
 package com.jayway.jsonpath.old;
 
-import com.jayway.jsonpath.*;
+import com.jayway.jsonpath.BaseTest;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Filter;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -14,11 +19,9 @@ import java.util.regex.Pattern;
 import static com.jayway.jsonpath.Criteria.where;
 import static com.jayway.jsonpath.Filter.filter;
 import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class FilterTest extends BaseTest {
 

--- a/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/old/FilterTest.java
@@ -1,10 +1,6 @@
 package com.jayway.jsonpath.old;
 
-import com.jayway.jsonpath.BaseTest;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.Filter;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Predicate;
+import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -160,14 +156,16 @@ public class FilterTest extends BaseTest {
         check.put("item", 3);
         check.put("null_item", null);
 
-        assertTrue(filter(where("item").nin(4, 5)).apply(createPredicateContext(check)));
-        assertTrue(filter(where("item").nin(asList(4, 5))).apply(createPredicateContext(check)));
-        assertTrue(filter(where("item").nin(asList('A'))).apply(createPredicateContext(check)));
-        assertTrue(filter(where("null_item").nin(1, 2, 3)).apply(createPredicateContext(check)));
-        assertTrue(filter(where("item").nin(asList((Object) null))).apply(createPredicateContext(check)));
-
-        assertFalse(filter(where("item").nin(3)).apply(createPredicateContext(check)));
-        assertFalse(filter(where("item").nin(asList(3))).apply(createPredicateContext(check)));
+//        assertTrue(filter(where("item").nin(4, 5)).apply(createPredicateContext(check)));
+//        assertTrue(filter(where("item").nin(asList(4, 5))).apply(createPredicateContext(check)));
+//        assertTrue(filter(where("item").nin(asList('A'))).apply(createPredicateContext(check)));
+//        assertTrue(filter(where("null_item").nin(1, 2, 3)).apply(createPredicateContext(check)));
+//        assertTrue(filter(where("item").nin(asList((Object) null))).apply(createPredicateContext(check)));
+//
+//        assertFalse(filter(where("item").nin(3)).apply(createPredicateContext(check)));
+//        assertFalse(filter(where("item").nin(asList(3))).apply(createPredicateContext(check)));
+        assertFalse(filter(where("not_existent_item").nin(3)).apply(createPredicateContext(check, Option.STRICT_MODE)));
+        assertFalse(filter(where("not_existent_item").nin(asList(3))).apply(createPredicateContext(check, Option.STRICT_MODE)));
     }
 
     @Test


### PR DESCRIPTION
Based on [Issue 940](https://github.com/json-path/JsonPath/issues/940)

If we have some data
`Map<String, Object> check = new HashMap<String, Object>();
        check.put("item", 3);
        check.put("null_item", null);`

and we use this filter
`filter(where("not_existent_item").nin(3)).apply(createPredicateContext(check))`
I expect to get false because no such element exists.
Instead the filter returns true.

This PR adds a new STRICT_MODE Option that will validate that all attributes in the filter are present in the json. If an attribute is not present, the filter will return false. This is a fix to NIN specifically. Because NIN inverts the output of IN there is no check if the attribute actually exists in the json.
Adding this mode will not change existing behavior.