### PR TITLE
Fix for max() does not return negative Double #942

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/Max.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/function/numeric/Max.java
@@ -6,7 +6,7 @@ package com.jayway.jsonpath.internal.function.numeric;
  * Created by mattg on 6/26/15.
  */
 public class Max extends AbstractAggregation {
-    private Double max = Double.MIN_VALUE;
+    private Double max = -1*Double.MAX_VALUE;
 
     @Override
     protected void next(Number value) {


### PR DESCRIPTION
"Double.MIN_VALUE" returns the smallest positive nonzero value of type double. Its a not a actual negative value of Double. So applied the changes to get the actual lowest Double value. 