### PR TITLE
Fixed rendering error on `$..book[?(@.price <= $['expensive'])]` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,20 +85,21 @@ Functions
 Functions can be invoked at the tail end of a path - the input to a function is the output of the path expression.
 The function output is dictated by the function itself.
 
-| Function  | Description                                                                          | Output type          |
-|:----------|:-------------------------------------------------------------------------------------|:---------------------|
-| min()     | Provides the min value of an array of numbers                                        | Double               |
-| max()     | Provides the max value of an array of numbers                                        | Double               |
-| avg()     | Provides the average value of an array of numbers                                    | Double               | 
-| stddev()  | Provides the standard deviation value of an array of numbers                         | Double               | 
-| length()  | Provides the length of an array                                                      | Integer              |
-| sum()     | Provides the sum value of an array of numbers                                        | Double               |
-| keys()    | Provides the property keys (An alternative for terminal tilde `~`)                   | `Set<E>`             |
-| concat(X) | Provides a concatinated version of the path output with a new item                   | like input           |
-| append(X) | add an item to the json path output array                                            | like input           |
-| first()   | Provides the first item of an array                                                  | Depends on the array |
-| last()    | Provides the last item of an array                                                   | Depends on the array |
-| index(X)  | Provides the item of an array of index: X, if the X is negative, take from backwards | Depends on the array |
+| Function    | Description                                                                          | Output type          |
+|:------------|:-------------------------------------------------------------------------------------|:---------------------|
+| `min()`     | Provides the min value of an array of numbers                                        | Double               |
+| `max()`     | Provides the max value of an array of numbers                                        | Double               |
+| `avg()`     | Provides the average value of an array of numbers                                    | Double               | 
+| `stddev()`  | Provides the standard deviation value of an array of numbers                         | Double               | 
+| `length()`  | Provides the length of an array                                                      | Integer              |
+| `sum()`     | Provides the sum value of an array of numbers                                        | Double               |
+| `keys()`    | Provides the property keys (An alternative for terminal tilde `~`)                   | `Set<E>`             |
+| `concat(X)` | Provides a concatinated version of the path output with a new item                   | like input           |
+| `append(X)` | add an item to the json path output array                                            | like input           |
+| `first()`   | Provides the first item of an array                                                  | Depends on the array |
+| `last()`    | Provides the last item of an array                                                   | Depends on the array |
+| `index(X)`  | Provides the item of an array of index: X, if the X is negative, take from backwards | Depends on the array |
+
 Filter Operators
 -----------------
 
@@ -106,20 +107,20 @@ Filters are logical expressions used to filter arrays. A typical filter would be
 
 | Operator                 | Description                                                           |
 | :----------------------- | :-------------------------------------------------------------------- |
-| ==                       | left is equal to right (note that 1 is not equal to '1')              |
-| !=                       | left is not equal to right                                            |
-| <                        | left is less than right                                               |
-| <=                       | left is less or equal to right                                        |
-| >                        | left is greater than right                                            |
-| >=                       | left is greater than or equal to right                                |
-| =~                       | left matches regular expression  [?(@.name =~ /foo.*?/i)]             |
-| in                       | left exists in right [?(@.size in ['S', 'M'])]                        |
-| nin                      | left does not exists in right                                         |
-| subsetof                 | left is a subset of right [?(@.sizes subsetof ['S', 'M', 'L'])]       |
-| anyof                    | left has an intersection with right [?(@.sizes anyof ['M', 'L'])]     |
-| noneof                   | left has no intersection with right [?(@.sizes noneof ['M', 'L'])]    |
-| size                     | size of left (array or string) should match right                     |
-| empty                    | left (array or string) should be empty                                |
+| `==`                     | left is equal to right (note that 1 is not equal to '1')              |
+| `!=`                     | left is not equal to right                                            |
+| `<`                      | left is less than right                                               |
+| `<=`                     | left is less or equal to right                                        |
+| `>`                      | left is greater than right                                            |
+| `>=`                     | left is greater than or equal to right                                |
+| `=~`                     | left matches regular expression  [?(@.name =~ /foo.*?/i)]             |
+| `in`                     | left exists in right [?(@.size in ['S', 'M'])]                        |
+| `nin`                    | left does not exists in right                                         |
+| `subsetof`               | left is a subset of right [?(@.sizes subsetof ['S', 'M', 'L'])]       |
+| `anyof`                  | left has an intersection with right [?(@.sizes anyof ['M', 'L'])]     |
+| `noneof`                 | left has no intersection with right [?(@.sizes noneof ['M', 'L'])]    |
+| `size`                   | size of left (array or string) should match right                     |
+| `empty`                  | left (array or string) should be empty                                |
 
 
 Path Examples
@@ -169,23 +170,23 @@ Given the json
 
 | JsonPath                                       | Result |
 |:-------------------------------------------------------------------| :----- |
-| $.store.book[*].author | The authors of all books     |
-| $..author                           | All authors                         |
-| $.store.*                           | All things, both books and bicycles  |
-| $.store..price                 | The price of everything         |
-| $..book[2]                         | The third book                      |
-| $..book[-2]                       | The second to last book            |
-| $..book[0,1]                     | The first two books               |
-| $..book[:2]                       | All books from index 0 (inclusive) until index 2 (exclusive) |
-| $..book[1:2]                     | All books from index 1 (inclusive) until index 2 (exclusive) |
-| $..book[-2:]                     | Last two books                   |
-| $..book[2:]                     | All books from index 2 (inclusive) to last  |
-| $..book[?(@.isbn)]                                                 | All books with an ISBN number         |
-| $.store.book[?(@.price < 10)]                                      | All books in store cheaper than 10  |
-| $..book[?(@.price <= $['expensive'])]                              | All books in store that are not "expensive"  |
-| $..book[?(@.author =~ /.*REES/i)]                                  | All books matching regex (ignore case)  |
-| $..*                                                               | Give me every thing   
-| $..book.length()                                                   | The number of books                      |
+| `$.store.book[*].author` | The authors of all books     |
+| `$..author`                           | All authors                         |
+| `$.store.*`                           | All things, both books and bicycles  |
+| `$.store..price`                 | The price of everything         |
+| `$..book[2]`                         | The third book                      |
+| `$..book[-2]`                       | The second to last book            |
+| `$..book[0,1]`                     | The first two books               |
+| `$..book[:2]`                       | All books from index 0 (inclusive) until index 2 (exclusive) |
+| `$..book[1:2]`                     | All books from index 1 (inclusive) until index 2 (exclusive) |
+| `$..book[-2:]`                     | Last two books                   |
+| `$..book[2:]`                     | All books from index 2 (inclusive) to last  |
+| `$..book[?(@.isbn)]`                                                 | All books with an ISBN number         |
+| `$.store.book[?(@.price < 10)]`                                      | All books in store cheaper than 10  |
+| `$..book[?(@.price <= $['expensive'])]`                              | All books in store that are not "expensive"  |
+| `$..book[?(@.author =~ /.*REES/i)]`                                  | All books matching regex (ignore case)  |
+| `$..*`                                                               | Give me every thing   
+| `$..book.length()`                                                   | The number of books                      |
 
 Reading a Document
 ------------------


### PR DESCRIPTION
Add code blocks and fix error that says **Misplaced @** because of two dollar signs ($) in a JsonPath expression in Path Examples section for `$..book[?(@.price <= $['expensive'])]`