### PR TITLE
Check for the existence of the next significant bracket

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -625,7 +625,11 @@ public class PathCompiler {
             fail("Property has not been closed - missing closing " + potentialStringDelimiter);
         }
 
-        int endBracketIndex = path.indexOfNextSignificantChar(endPosition, CLOSE_SQUARE_BRACKET) + 1;
+        int endBracketIndex = path.indexOfNextSignificantChar(endPosition, CLOSE_SQUARE_BRACKET);
+        if(endBracketIndex == -1) {
+            fail("Property has not been closed - missing closing ]");
+        }
+        endBracketIndex++;
 
         path.setPosition(endBracketIndex);
 

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_970.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_970.java
@@ -1,0 +1,12 @@
+package com.jayway.jsonpath;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class Issue_970 {
+    @Test
+    public void shouldNotCauseStackOverflow() {
+        assertThatNoException().isThrownBy(() -> Criteria.where("[']',"));
+    }
+}

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_973.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_973.java
@@ -1,0 +1,12 @@
+package com.jayway.jsonpath;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class Issue_973 {
+    @Test
+    public void shouldNotCauseStackOverflow() {
+        assertThatNoException().isThrownBy(() -> Criteria.parse("@[\"\",/\\"));
+    }
+}


### PR DESCRIPTION
This PR shows a simple fix for the [CVE-2023-51074](https://github.com/advisories/GHSA-pfh2-hfmq-phg5).
It consists of a simple check whether a closing bracket actually exists.

Closes #970, Closes #973