### PR TITLE
Fix logic of parsing function with no arguments.

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -235,7 +235,7 @@ public class PathCompiler {
                     String functionName = path.subSequence(startPosition, endPosition).toString();
                     functionParameters = parseFunctionParameters(functionName);
                 } else {
-                    path.setPosition(readPosition + 1);
+                    path.setPosition(readPosition + 2);
                 }
             }
             else {


### PR DESCRIPTION
Currently a function with no arguments is not parsed correctly. Given `$.objects.keys().size()`, after encountering keys (a function with no arguments) the position should move from $.objects.keys`(`).size() to $.objects.keys()`.`size(). But in current implementation read position moves from $.objects.keys`(`).size() to $.objects.keys(`)`.size()

This pull request will fix this issue.