### PR TITLE
Add support for trailing newline character in path to evaluate on a json

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -74,7 +74,7 @@ public class JsonContext implements DocumentContext {
     @Override
     public <T> T read(String path, Predicate... filters) {
         notEmpty(path, "path can not be null or empty");
-        return read(pathFromCache(path, filters));
+        return read(pathFromCache(path.trim(), filters));
     }
 
     @Override

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_1001.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_1001.java
@@ -1,0 +1,20 @@
+package com.jayway.jsonpath;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue_1001 {
+    @Test
+    public void testTrailingNewlineInPath() {
+        String context = "{\n" +
+                "  \"level_0\": {\n" +
+                "    \"level_1\": {\n" +
+                "      \"level_2\": \"At level 2\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        String result = JsonPath.read(context, "$.level_0.level_1.level_2\n");
+        assertThat(result).isEqualTo("At level 2");
+    }
+}


### PR DESCRIPTION
* This code change address the issue reported in https://github.com/json-path/JsonPath/issues/1001

* This code change handles trailing newline character present in a path which needs to be evaluated on a json document.

* A new test case has been added to test this change.