### PR TITLE
Upgrade net.minidev:json-smart from 2.5.0 to 2.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 ext {
     libs = [
-            jsonSmart      : 'net.minidev:json-smart:2.5.0',
+            jsonSmart      : 'net.minidev:json-smart:2.5.1',
             slf4jApi       : 'org.slf4j:slf4j-api:2.0.11',
             gson           : 'com.google.code.gson:gson:2.10.1',
             hamcrest       : 'org.hamcrest:hamcrest:2.2',


### PR DESCRIPTION
It's good to keep dependencies up-to-date. There is a newer version of `json-smart` (2.5.1), released at March 21.