### PR TITLE
[CI] Remove Java 18 from build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17, 18, 21 ]
+        java: [ 8, 11, 17, 21 ]
       fail-fast: false
       max-parallel: 4
     name: JDK ${{ matrix.java }}


### PR DESCRIPTION
Java 18 is not LTS and it's already reached EOL.