### PR TITLE
Upgrade org.json:json from 20231013 to 20240303

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
             hamcrest       : 'org.hamcrest:hamcrest:2.2',
             jacksonDatabind: 'com.fasterxml.jackson.core:jackson-databind:2.16.1',
             jettison       : 'org.codehaus.jettison:jettison:1.5.4',
-            jsonOrg        : 'org.json:json:20231013',
+            jsonOrg        : 'org.json:json:20240303',
             tapestryJson   : 'org.apache.tapestry:tapestry-json:5.8.3',
             jakartaJsonP   : 'jakarta.json:jakarta.json-api:2.0.2',
             jakartaJsonB   : 'jakarta.json.bind:jakarta.json.bind-api:2.0.0',

--- a/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/spi/json/JsonOrgJsonProvider.java
@@ -5,7 +5,6 @@ import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPathException;
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.json.JSONTokener;
 
 import java.io.InputStream;
@@ -128,6 +127,7 @@ public class JsonOrgJsonProvider extends AbstractJsonProvider {
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public void removeProperty(Object obj, Object key) {
         if (isMap(obj))


### PR DESCRIPTION
This PR upgrades JsonOrg to the latest version available at Maven Central:
https://mvnrepository.com/artifact/org.json/json/20240303

An unused import was also removed from the `JsonOrgJsonProvider` class.