### PR TITLE
feat: Fix multiple nested calls

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathCompiler.java
@@ -349,15 +349,11 @@ public class PathCompiler {
                 // we've encountered a COMMA do the same
                 case CLOSE_PARENTHESIS:
                     groupParen--;
-                    //CS304 Issue link: https://github.com/json-path/JsonPath/issues/620
-                    if (0 > groupParen || priorChar == '(') {
-                        parameter.append(c);
-                    }
                 case COMMA:
                     // In this state we've reach the end of a function parameter and we can pass along the parameter string
                     // to the parser
                     if ((0 == groupQuote && 0 == groupBrace && 0 == groupBracket
-                            && ((0 == groupParen && CLOSE_PARENTHESIS == c) || 1 == groupParen))) {
+                            && ((0 == groupParen && CLOSE_PARENTHESIS == c) || (1 == groupParen && c == COMMA)))) {
                         endOfStream = (0 == groupParen);
 
                         if (null != type) {

--- a/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/internal/function/NestedFunctionTest.java
@@ -75,6 +75,14 @@ public class NestedFunctionTest extends BaseFunctionTest {
 
     @ParameterizedTest
     @MethodSource("configurations")
+    public void testMultipleCall(Configuration conf) {
+        verifyTextFunction(conf, "$.concat($.text[0], $.concat( $.concat($.text[3], \"-1\"), $.concat($.text[4], \"-1\")))", "ad-1e-1");
+    }
+
+
+
+    @ParameterizedTest
+    @MethodSource("configurations")
     public void testStringAndNumberConcat(Configuration conf) {
         verifyTextAndNumberFunction(conf, "$.concat($.text[0], $.numbers[0])", "a1");
     }


### PR DESCRIPTION
When multiple nested calls were added it skipped the last parenthesis, preventing the nested functions to compile