### PR TITLE
#1016  PR for Filters like IN cannot process objects and arrays inside arrays

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNode.java
@@ -5,9 +5,13 @@ import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.internal.Path;
 import com.jayway.jsonpath.internal.path.PathCompiler;
+import net.minidev.json.JSONArray;
 import net.minidev.json.parser.JSONParser;
 
 import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static com.jayway.jsonpath.internal.filter.ValueNodes.*;
@@ -175,6 +179,8 @@ public abstract class ValueNode {
         else if(o instanceof Boolean) return createBooleanNode(o.toString());
         else if(o instanceof Pattern) return createPatternNode((Pattern)o);
         else if (o instanceof OffsetDateTime) return createOffsetDateTimeNode(o.toString());  //workaround for issue: https://github.com/json-path/JsonPath/issues/613
+        else if (o instanceof Map) return new JsonNode(o);
+        else if (o instanceof JSONArray) return new ValueListNode(Collections.unmodifiableList((List) o));
         else throw new JsonPathException("Could not determine value type");
 
     }
@@ -235,4 +241,3 @@ public abstract class ValueNode {
 
 
 }
-

--- a/json-path/src/test/java/com/jayway/jsonpath/Issue_1016.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/Issue_1016.java
@@ -1,0 +1,52 @@
+package com.jayway.jsonpath;
+
+import org.junit.jupiter.api.Test;
+
+
+public class Issue_1016
+{
+    public static final Configuration jsonConf = Configuration.defaultConfiguration();
+
+    @Test
+    public void test_read_with_empty_array()
+    {
+        // Before fix:
+        // assertEvaluationThrows("[{\"id\":1,\"array\":[\"a\",{\"b\":\"c\"}]}]", "$.*[?(\"a\" in @.array)]", JsonPathException.class);
+
+        DocumentContext emptyArray = JsonPath.using(jsonConf).parse("[{\"id\":1,\"array\":[\"a\",[]]}]");
+        Object read = emptyArray.read("$.*[?(\"a\" in @.array)]");
+        assert(read.toString().equals("[{\"id\":1,\"array\":[\"a\",[]]}]"));
+    }
+
+    @Test
+    public void test_read_with_filled_array()
+    {
+        DocumentContext filledArray = JsonPath.using(jsonConf).parse("[{\"id\":1,\"array\":[\"a\",[\"b\", \"c\"]]}]");
+        Object read = filledArray.read("$.*[?(\"a\" in @.array)]");
+        assert(read.toString().equals("[{\"id\":1,\"array\":[\"a\",[\"b\",\"c\"]]}]"));
+    }
+
+    @Test
+    public void test_read_with_empty_object()
+    {
+        DocumentContext emptyObj = JsonPath.using(jsonConf).parse("[{\"id\":1,\"array\":[\"a\",{}]}]");
+        Object read = emptyObj.read("$.*[?(\"a\" in @.array)]");
+        assert(read.toString().equals("[{\"id\":1,\"array\":[\"a\",{}]}]"));
+    }
+
+    @Test
+    public void test_read_with_filled_object()
+    {
+        DocumentContext filledObj = JsonPath.using(jsonConf).parse("[{\"id\":1,\"array\":[\"a\",{\"b\":\"c\"}]}]");
+        Object read = filledObj.read("$.*[?(\"a\" in @.array)]");
+        assert(read.toString().equals("[{\"id\":1,\"array\":[\"a\",{\"b\":\"c\"}]}]"));
+    }
+
+    @Test
+    public void test_read_with_combined_elements()
+    {
+        DocumentContext combined = JsonPath.using(jsonConf).parse("[{\"id\":1,\"array\":[\"a\",[\"b\", {\"c\" :  \"d\"}]]}]");
+        Object read = combined.read("$.*[?(\"a\" in @.array)]");
+        assert(read.toString().equals("[{\"id\":1,\"array\":[\"a\",[\"b\",{\"c\":\"d\"}]]}]"));
+    }
+}


### PR DESCRIPTION
Fixed that issue by adding support for Maps and `JSONArray` to `ValueNode`. Also added some tests.

Fixes #1016 