### PR TITLE
Add method for using filter predicates w/ typeRef

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/ReadContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/ReadContext.java
@@ -61,6 +61,17 @@ public interface ReadContext {
     /**
      * Reads the given path from this context
      *
+     * @param path    path to read
+     * @param typeRef  expected return type (will try to map)
+     * @param filters filters
+     * @param <T>
+     * @return result
+     */
+    <T> T read(String path, TypeRef<T> typeRef, Predicate... filters);
+
+    /**
+     * Reads the given path from this context
+     *
      * @param path path to apply
      * @param <T>
      * @return result

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/JsonContext.java
@@ -83,6 +83,11 @@ public class JsonContext implements DocumentContext {
     }
 
     @Override
+    public <T> T read(String path, TypeRef<T> type, Predicate... filters) {
+        return convert(read(path, filters), type, configuration);
+    }
+
+    @Override
     public <T> T read(JsonPath path) {
         notNull(path, "path can not be null");
         return path.read(json, configuration);

--- a/json-path/src/test/java/com/jayway/jsonpath/PredicateTest.java
+++ b/json-path/src/test/java/com/jayway/jsonpath/PredicateTest.java
@@ -23,4 +23,18 @@ public class PredicateTest extends BaseTest {
 
         assertThat(reader.read("$.store.book[?].isbn", List.class, booksWithISBN)).containsOnly("0-395-19395-8", "0-553-21311-3");
     }
+
+    @Test
+    public void predicates_filters_can_be_applied_with_type_ref() {
+        TypeRef<List<String>> typeRef = new TypeRef<List<String>>() {
+        };
+        Predicate booksWithISBN = new Predicate() {
+            @Override
+            public boolean apply(PredicateContext ctx) {
+                return ctx.item(Map.class).containsKey("isbn");
+            }
+        };
+
+        assertThat(reader.read("$.store.book[?].isbn", typeRef, booksWithISBN)).containsOnly("0-395-19395-8", "0-553-21311-3");
+    }
 }


### PR DESCRIPTION
The read methods that take a `Predicate...` were missing a typeRef variant.