### PR TITLE
Fix CVE-2024-57699 for json-smart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 ext {
     libs = [
-            jsonSmart      : 'net.minidev:json-smart:2.5.1',
+            jsonSmart      : 'net.minidev:json-smart:2.5.2',
             slf4jApi       : 'org.slf4j:slf4j-api:2.0.11',
             gson           : 'com.google.code.gson:gson:2.10.1',
             hamcrest       : 'org.hamcrest:hamcrest:2.2',


### PR DESCRIPTION
Fixed  CVE-2024-57699 for json-smart

For more information: https://github.com/TurtleLiu/Vul_PoC/tree/main/CVE-2024-57699
Changelog: https://github.com/netplex/json-smart-v2