### PR TITLE
Expose more path fragment operations to public API

### DIFF
--- a/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/JsonPath.java
@@ -96,7 +96,7 @@ public class JsonPath {
         notNull(jsonPath, "path can not be null");
         this.path = PathCompiler.compile(jsonPath, filters);
     }
-
+    
     /**
      * Returns the string representation of this JsonPath
      *
@@ -104,6 +104,14 @@ public class JsonPath {
      */
     public String getPath() {
         return this.path.toString();
+    }
+    
+    /**
+     * Gets the internal path implementation. For advanced use cases.
+     * @return the path implementation
+     */
+    public Path getPathImpl() {
+    	return path;
     }
 
     /**

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayIndexToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/ArrayIndexToken.java
@@ -14,9 +14,9 @@
  */
 package com.jayway.jsonpath.internal.path;
 
-import com.jayway.jsonpath.internal.PathRef;
+import java.util.List;
 
-import static java.lang.String.format;
+import com.jayway.jsonpath.internal.PathRef;
 
 public class ArrayIndexToken extends ArrayPathToken {
 
@@ -48,5 +48,8 @@ public class ArrayIndexToken extends ArrayPathToken {
     public boolean isTokenDefinite() {
         return arrayIndexOperation.isSingleIndexOperation();
     }
-
+    
+    public List<Integer> getIndexes() {
+    	return arrayIndexOperation.indexes();
+    }
 }

--- a/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
+++ b/json-path/src/main/java/com/jayway/jsonpath/internal/path/PathToken.java
@@ -222,7 +222,7 @@ public abstract class PathToken {
 
     public abstract boolean isTokenDefinite();
 
-    protected abstract String getPathFragment();
+    public abstract String getPathFragment();
 
     public void setNext(final PathToken next) {
         this.next = next;
@@ -230,5 +230,9 @@ public abstract class PathToken {
 
     public PathToken getNext() {
         return this.next;
+    }
+    
+    public PathToken getPrevious() {
+    	return this.prev;
     }
 }


### PR DESCRIPTION
JsonPath does not create intermediary objects/paths as discussed in #256 , and it shouldn't.  However, if you want to do this yourself, very helpful aspects of the JsonPath API are marked as private/protected. 

One operation that I was surprised to see was quite difficult was to evaluate a JsonPath at the "immediate parent", something like `root -> tail -> previous`.

I was able to achieve this using hacky reflection, so this PR opening up the APIs I needed to call with forced reflection access.

1. `PathToken.getPathFragment` seems like the most obvious- the abstract class marks it as `protected` but all child implementing classes are `public`. Not sure why it's protected.
2. `PathToken.getPrevoius` is already available as `prev()` but it's package-private. If we're willing to expose `getNext` why not `getPrev`?
3. Instantiating intermediary objects through arrays require knowing what index we're on, so `ArrayIndexToken.getIndexes` gives a mechanism for that without exposing the entire `ArrayIndexOperation`. This doesn't support slicing, but since it's just a simple getter, it's not promising full support or new functionality.
4. The most controversial one is likely my `getPathImpl`. This is the entry point to all these helpful path fragment/path token APIs from a `JsonPath` but I understand how it's confusing with `String getPath` and might be something you don't want to expose. 